### PR TITLE
replaceImage FIX : removed options

### DIFF
--- a/dist/image-sequencer.js
+++ b/dist/image-sequencer.js
@@ -35029,7 +35029,7 @@ function ReplaceImage(ref,selector,steps,options) {
     else make(url);
 
     function make(url) {
-      this_.loadImage('default',url).addSteps('default',steps,options).run(function(out){
+      this_.loadImage('default',url).addSteps('default',steps).run(function(out){
         the_image.src = out;
       });
     }

--- a/src/ReplaceImage.js
+++ b/src/ReplaceImage.js
@@ -25,7 +25,7 @@ function ReplaceImage(ref,selector,steps,options) {
     else make(url);
 
     function make(url) {
-      this_.loadImage('default',url).addSteps('default',steps,options).run(function(out){
+      this_.loadImage('default',url).addSteps('default',steps).run(function(out){
         the_image.src = out;
       });
     }


### PR DESCRIPTION
Hey. The `options` commit actually broke the entire method. By the time I figure this out, I am removing `options`. I apologise for merging that last commit without fully testing it. I was just too excited.