### PR TITLE
Revived Crop Module

### DIFF
--- a/src/AddStep.js
+++ b/src/AddStep.js
@@ -3,7 +3,7 @@ function AddStep(ref, image, name, o) {
   function addStep(image, name, o_) {
     ref.log('\x1b[36m%s\x1b[0m','adding step \"' + name + '\" to \"' + image + '\".');
 
-    o = {};
+    o = ref.copy(o_);
     o.id = ref.options.sequencerCounter++; //Gives a Unique ID to each step
     o.name = o_.name || name;
     o.selector = o_.selector || 'ismod-' + name;

--- a/src/Modules.js
+++ b/src/Modules.js
@@ -6,5 +6,6 @@ module.exports = {
   'green-channel': require('./modules/GreenChannel'),
   'ndvi-red': require('./modules/NdviRed'),
   'do-nothing-pix': require('./modules/DoNothingPix'),
-  'invert': require('./modules/Invert')
+  'invert': require('./modules/Invert'),
+  'crop': require('./modules/Crop')
 }

--- a/src/modules/Crop.js
+++ b/src/modules/Crop.js
@@ -13,18 +13,20 @@
  *          y = options.y
  *          y = options.y + options.h
  */
- module.exports = function Crop(options){
-
+ module.exports = function Crop(options) {
    options = options || {};
-   options.title = "Crop Image";
-   options.format = options.format || "png";
+   options.title = "Do Nothing";
+   this_ = this;
+   var output
+   var getPixels = require("get-pixels"),
+       savePixels = require("save-pixels"),
+       base64 = require('base64-stream');
 
-   function draw(image) {
-     var getPixels = require("get-pixels"),
-         savePixels = require("save-pixels"),
-         base64 = require('base64-stream');
+   function draw(input,callback) {
 
-     getPixels(image.src,function(err,pixels){
+     const this_ = this;
+
+     getPixels(input.src,function(err,pixels){
        var newdata = [];
        var ox = options.x || 0;
        var oy = options.y || 0;
@@ -39,23 +41,23 @@
        pixels.shape = [w,h,4];
        pixels.stride[1] = 4*w;
 
-       var buffer = base64.encode();
-       savePixels(pixels, options.format)
-         .on('end', function() {
+       options.format = "jpeg";
 
-         var img = new Image();
-
-         img.src = 'data:image/' + options.format + ';base64,' + buffer.read().toString();
-
-         if (options.output) options.output(img);
-
-       }).pipe(buffer);
-
+       w = base64.encode();
+       var r = savePixels(pixels, options.format);
+       r.pipe(w).on('finish',function(){
+         data = w.read().toString();
+         datauri = 'data:image/' + options.format + ';base64,' + data;
+         this_.output = {src:datauri,format:options.format};
+         callback();
+       });
      });
+
    }
 
    return {
      options: options,
-     draw: draw
+     draw: draw,
+     output: output
    }
  }


### PR DESCRIPTION
## What this PR contains
Hello!
I have revived my first module, the crop module!
## Usage
```js
sequencer.loadImages('PATH_TO_IMAGE').addSteps('crop',options);
```
### Where:
![Crop Manual](http://preview.ibb.co/c1d00F/Crop_Manual.png)
* `options.x` is the x-offset of the crop from the left
* `options.y` is the y-offset of the crop from the top
* `options.w` is the width of the resultant crop
* `options.h` is the height of the resultant crop

### Defaults:
`options.x` : 0
`options.y` : 0
`options.w` : half of image width
`options.h` : half of image height
