### PR TITLE
Removed Global Variables, Added a Test to check this

### DIFF
--- a/dist/image-sequencer.js
+++ b/dist/image-sequencer.js
@@ -34564,7 +34564,7 @@ function AddStep(ref, image, name, o) {
   function addStep(image, name, o_) {
     ref.log('\x1b[36m%s\x1b[0m','adding step \"' + name + '\" to \"' + image + '\".');
 
-    o = ref.copy(o_);
+    var o = ref.copy(o_);
     o.id = ref.options.sequencerCounter++; //Gives a Unique ID to each step
     o.name = o_.name || name;
     o.selector = o_.selector || 'ismod-' + name;
@@ -34611,7 +34611,7 @@ function copy(a) {
   if (objTypeOf(a) == "Array") return a.slice();
   if (objTypeOf(a) == "Object") {
     var b = {};
-    for (v in a) {
+    for (var v in a) {
       b[v] = copy(a[v]);
     }
     return b;
@@ -34621,11 +34621,11 @@ function copy(a) {
 
 function formatInput(args,format,images) {
   images = [];
-  for (image in this.images) {
+  for (var image in this.images) {
     images.push(image);
   }
-  json_q = {};
-  format_i = format;
+  var json_q = {};
+  var format_i = format;
   if (format == "+")
     format = ['o_string_a', 'string_a', 'o_object'];
   else if (format == "-")
@@ -34672,8 +34672,8 @@ function formatInput(args,format,images) {
 
   if(format[0] == "o_string_a") {
     if(args.length == format.length - 1) {
-      insert = false;
-      for (i in args) {
+      var insert = false;
+      for (var i in args) {
         if (format[parseInt(i)+1].includes( typeof(getPrimitive(args[i])) )){
           insert = true;
         }
@@ -34685,15 +34685,15 @@ function formatInput(args,format,images) {
   }
   else if (format[0] == "o_string" && format_i == "l" && args.length == 2) {
     if (typeof(args[0]) == "string") {
-      identifier = "image";
-      number = 1;
+      var identifier = "image";
+      var number = 1;
       while (this.images.hasOwnProperty(identifier+number)) number++;
       args.splice(0,0,identifier+number);
     }
   }
 
   if(args.length == format.length) {
-    for (i in format) {
+    for (var i in format) {
       if (format[i].substr(format[i].length-2,2)=="_a")
         args[i] = makeArray(args[i]);
     }
@@ -34702,12 +34702,12 @@ function formatInput(args,format,images) {
   if (args.length == 1) {
     json_q = copy(args[0]);
     if(!(format_i == "r" || format_i == "l")) {
-      for (img in json_q)
+      for (var img in json_q)
         json_q[img] = makeArray(json_q[img]);
     }
   }
   else if (format_i == "r") {
-    for (img in args[0]) json_q[args[0][img]] = args[1];
+    for (var img in args[0]) json_q[args[0][img]] = args[1];
   }
   else if (format_i == "l") {
     json_q = {
@@ -34717,12 +34717,12 @@ function formatInput(args,format,images) {
     json_q.images[args[0]] = args[1];
   }
   else {
-    for (img in args[0]) {
-      image = args[0][img];
+    for (var img in args[0]) {
+      var image = args[0][img];
       json_q[image] = [];
 
       if(format_i == "+") {
-        for(s in args[1]) {
+        for(var s in args[1]) {
           json_q[image].push({
             name: args[1][s],
             o: args[2]
@@ -34735,8 +34735,8 @@ function formatInput(args,format,images) {
       }
 
       if(format_i == "^") {
-        size = this.images[image].steps.length;
-        index = args[1];
+        var size = this.images[image].steps.length;
+        var index = args[1];
         index = (index==size)?index:index%size;
         if (index<0) index += size+1;
         json_q[image].push({
@@ -34751,7 +34751,7 @@ function formatInput(args,format,images) {
 
   if(format_i == "l") {
     json_q.loadedimages = [];
-    for (i in json_q.images) json_q.loadedimages.push(i);
+    for (var i in json_q.images) json_q.loadedimages.push(i);
   }
 
   return json_q;
@@ -34786,7 +34786,7 @@ ImageSequencer = function ImageSequencer(options) {
     if (objTypeOf(a) == "Array") return a.slice();
     if (objTypeOf(a) == "Object") {
       var b = {};
-      for (v in a) {
+      for (var v in a) {
         b[v] = copy(a[v]);
       }
       return b;
@@ -34798,11 +34798,10 @@ ImageSequencer = function ImageSequencer(options) {
     return (objTypeOf(input)=="Array")?input:[input];
   }
 
-  formatInput = require('./FormatInput');
-
   var image,
       steps = [],
       modules = require('./Modules'),
+      formatInput = require('./FormatInput'),
       images = {},
       inputlog = [];
 
@@ -34812,15 +34811,15 @@ ImageSequencer = function ImageSequencer(options) {
 
   function addSteps(){
     const this_ = (this.name == "ImageSequencer")?this:this.sequencer;
-    args = (this.name == "ImageSequencer")?[]:[this.images];
-    json_q = {};
-    for(arg in arguments){args.push(copy(arguments[arg]));}
+    var args = (this.name == "ImageSequencer")?[]:[this.images];
+    var json_q = {};
+    for(var arg in arguments){args.push(copy(arguments[arg]));}
     json_q = formatInput.call(this_,args,"+");
 
     inputlog.push({method:"addSteps", json_q:copy(json_q)});
 
-    for (i in json_q)
-      for (j in json_q[i])
+    for (var i in json_q)
+      for (var j in json_q[i])
         require("./AddStep")(this_,i,json_q[i][j].name,json_q[i][j].o);
 
     return this;
@@ -34836,18 +34835,18 @@ ImageSequencer = function ImageSequencer(options) {
   }
 
   function removeSteps(image,index) {
-    run = {};
+    var run = {}, indices;
     const this_ = (this.name == "ImageSequencer")?this:this.sequencer;
-    args = (this.name == "ImageSequencer")?[]:[this.images];
-    for(arg in arguments) args.push(copy(arguments[arg]));
+    var args = (this.name == "ImageSequencer")?[]:[this.images];
+    for(var arg in arguments) args.push(copy(arguments[arg]));
 
-    json_q = formatInput.call(this_,args,"-");
+    var json_q = formatInput.call(this_,args,"-");
     inputlog.push({method:"removeSteps", json_q:copy(json_q)});
 
-    for (img in json_q) {
+    for (var img in json_q) {
       indices = json_q[img].sort(function(a,b){return b-a});
       run[img] = indices[indices.length-1];
-      for (i in indices)
+      for (var i in indices)
         removeStep(img,indices[i]);
     }
     // this.run(run); // This is creating problems
@@ -34855,18 +34854,18 @@ ImageSequencer = function ImageSequencer(options) {
   }
 
   function insertSteps(image, index, name, o) {
-    run = {};
+    var run = {};
     const this_ = (this.name == "ImageSequencer")?this:this.sequencer;
-    args = (this.name == "ImageSequencer")?[]:[this.images];
-    for (arg in arguments) args.push(arguments[arg]);
+    var args = (this.name == "ImageSequencer")?[]:[this.images];
+    for (var arg in arguments) args.push(arguments[arg]);
 
-    json_q = formatInput.call(this_,args,"^");
+    var json_q = formatInput.call(this_,args,"^");
     inputlog.push({method:"insertSteps", json_q:copy(json_q)});
 
-    for (img in json_q) {
+    for (var img in json_q) {
       var details = json_q[img];
       details = details.sort(function(a,b){return b.index-a.index});
-      for (i in details)
+      for (var i in details)
         require("./InsertStep")(this_,img,details[i].index,details[i].name,details[i].o);
       run[img] = details[details.length-1].index;
     }
@@ -34877,15 +34876,15 @@ ImageSequencer = function ImageSequencer(options) {
   function run(t_image,t_from) {
     log('\x1b[32m%s\x1b[0m',"Running the Sequencer!");
     const this_ = (this.name == "ImageSequencer")?this:this.sequencer;
-    args = (this.name == "ImageSequencer")?[]:[this.images];
+    var args = (this.name == "ImageSequencer")?[]:[this.images];
     for (var arg in arguments) args.push(copy(arguments[arg]));
 
-    callback = function() {};
+    var callback = function() {};
     for (var arg in args)
       if(objTypeOf(args[arg]) == "Function")
         callback = args.splice(arg,1)[0];
 
-    json_q = formatInput.call(this_,args,"r");
+    var json_q = formatInput.call(this_,args,"r");
 
     require('./Run')(this_, json_q, callback);
 
@@ -34893,14 +34892,14 @@ ImageSequencer = function ImageSequencer(options) {
   }
 
   function loadImages() {
-    args = [];
-    for (arg in arguments) args.push(copy(arguments[arg]));
-    json_q = formatInput.call(this,args,"l");
+    var args = [];
+    for (var arg in arguments) args.push(copy(arguments[arg]));
+    var json_q = formatInput.call(this,args,"l");
 
     inputlog.push({method:"loadImages", json_q:copy(json_q)});
-    loadedimages = this.copy(json_q.loadedimages);
+    var loadedimages = this.copy(json_q.loadedimages);
 
-    for (i in json_q.images)
+    for (var i in json_q.images)
       require('./LoadImage')(this,i,json_q.images[i])
 
     json_q.callback();
@@ -34948,7 +34947,7 @@ function InsertStep(ref, image, index, name, o) {
   function insertStep(image, index, name, o_) {
     ref.log('\x1b[36m%s\x1b[0m','inserting step \"' + name + '\" to \"' + image + '\" at \"'+index+'\".');
 
-    o = ref.copy(o_);
+    var o = ref.copy(o_);
     o.id = ref.options.sequencerCounter++; //Gives a Unique ID to each step
     o.name = o.name || name;
     o.selector = o.selector || 'ismod-' + name;
@@ -34982,8 +34981,8 @@ module.exports = InsertStep;
 },{}],118:[function(require,module,exports){
 function LoadImage(ref, name, src) {
   function CImage(src) {
-    datauri = (ref.options.inBrowser || src.substring(0,11) == "data:image/")?(src):require('urify')(src);
-    image = {
+    var datauri = (ref.options.inBrowser || src.substring(0,11) == "data:image/")?(src):require('urify')(src);
+    var image = {
       src: datauri,
       format: datauri.split(':')[1].split(';')[0].split('/')[1]
     }
@@ -34991,7 +34990,7 @@ function LoadImage(ref, name, src) {
   }
 
   function loadImage(name, src) {
-    image = {
+    var image = {
       src: src,
       steps: [{
         options: {
@@ -35039,13 +35038,13 @@ module.exports = {
 },{"./modules/Crop/Module":123,"./modules/DoNothing/Module":124,"./modules/DoNothingPix/Module.js":125,"./modules/GreenChannel/Module":126,"./modules/Invert/Module":127,"./modules/NdviRed/Module":128,"./modules/SegmentedColormap/Module":129}],120:[function(require,module,exports){
 function ReplaceImage(ref,selector,steps,options) {
   if(!ref.options.inBrowser) return false; // This isn't for Node.js
-  this_ = ref;
+  var this_ = ref;
   var input = document.querySelectorAll(selector);
   var images = [];
-  for (i = 0; i < input.length; i++)
+  for (var i = 0; i < input.length; i++)
     if (input[i] instanceof HTMLImageElement) images.push(input[i]);
-  for (i in images) {
-    the_image = images[i];
+  for (var i in images) {
+    var the_image = images[i];
     var url = images[i].src;
     var ext = url.split('.').pop();
 
@@ -35077,47 +35076,47 @@ module.exports = ReplaceImage;
 function Run(ref, json_q, callback) {
   function drawStep(drawarray,pos) {
     if(pos==drawarray.length) {
-      image = drawarray[pos-1].image;
+      var image = drawarray[pos-1].image;
       if(ref.objTypeOf(callback)=='Function'){
-        steps = ref.images[image].steps;
-        out = steps[steps.length-1].output.src;
+        var steps = ref.images[image].steps;
+        var out = steps[steps.length-1].output.src;
         callback(out);
         return true;
       }
     }
-    image = drawarray[pos].image;
-    i = drawarray[pos].i;
-    input = ref.images[image].steps[i-1].output;
+    var image = drawarray[pos].image;
+    var i = drawarray[pos].i;
+    var input = ref.images[image].steps[i-1].output;
     ref.images[image].steps[i].draw(ref.copy(input),function(){
       drawStep(drawarray,++pos);
     });
   }
   function drawSteps(json_q) {
-    drawarray = [];
-    for (image in json_q) {
-      no_steps = ref.images[image].steps.length;
-      init = json_q[image];
-      for(i = 0; i < no_steps-init; i++) {
+    var drawarray = [];
+    for (var image in json_q) {
+      var no_steps = ref.images[image].steps.length;
+      var init = json_q[image];
+      for(var i = 0; i < no_steps-init; i++) {
         drawarray.push({image: image,i: init+i});
       }
     }
     drawStep(drawarray,0);
   }
   function filter(json_q){
-    for (image in json_q) {
+    for (var image in json_q) {
       if (json_q[image]==0 && ref.images[image].steps.length==1)
         delete json_q[image];
       else if (json_q[image]==0) json_q[image]++;
     }
-    for (image in json_q) {
-      prevstep = ref.images[image].steps[json_q[image]-1];
+    for (var image in json_q) {
+      var prevstep = ref.images[image].steps[json_q[image]-1];
       while (typeof(prevstep) == "undefined" || typeof(prevstep.output) == "undefined") {
         prevstep = ref.images[image].steps[(--json_q[image]) - 1];
       }
     }
     return json_q;
   }
-  json_q = filter(json_q);
+  var json_q = filter(json_q);
   return drawSteps(json_q);
 }
 module.exports = Run;
@@ -35176,7 +35175,7 @@ module.exports = function Crop(input,options,callback) {
  module.exports = function CropModule(options) {
    options = options || {};
    options.title = "Crop Image";
-   this_ = this;
+   var this_ = this;
    var output
 
    function draw(input,callback) {
@@ -35208,7 +35207,7 @@ module.exports = function Crop(input,options,callback) {
 module.exports = function DoNothing(options) {
   options = options || {};
   options.title = "Do Nothing";
-  this_ = this;
+  var this_ = this;
   var output
 
   function draw(input,callback) {
@@ -35234,7 +35233,7 @@ module.exports = function DoNothingPix(options) {
   var output;
 
   function draw(input,callback) {
-    this_ = this;
+    var this_ = this;
     function changePixel(r, g, b, a) {
       return [r, g, b, a];
     }
@@ -35271,7 +35270,7 @@ module.exports = function GreenChannel(options) {
   //function setup() {} // optional
 
   function draw(input,callback) {
-    this_ = this;
+    var this_ = this;
     function changePixel(r, g, b, a) {
       return [0, g, 0, a];
     }
@@ -35309,7 +35308,7 @@ module.exports = function GreenChannel(options) {
   //function setup() {} // optional
 
   function draw(input,callback) {
-    this_ = this;
+    var this_ = this;
     function changePixel(r, g, b, a) {
       return [255-r, 255-g, 255-b, a];
     }
@@ -35344,7 +35343,7 @@ module.exports = function NdviRed(options) {
   var output;
 
   function draw(input,callback) {
-    this_ = this;
+    var this_ = this;
     function changePixel(r, g, b, a) {
       var ndvi = (b - r) / (1.00 * b + r);
       var x = 255 * (ndvi + 1) / 2;
@@ -35376,7 +35375,7 @@ module.exports = function SegmentedColormap(options) {
   var output;
 
   function draw(input,callback) {
-    this_ = this;
+    var this_ = this;
     function changePixel(r, g, b, a) {
       var ndvi = (b - r) / (r + b);
       var normalized = (ndvi + 1) / 2;

--- a/src/AddStep.js
+++ b/src/AddStep.js
@@ -3,7 +3,7 @@ function AddStep(ref, image, name, o) {
   function addStep(image, name, o_) {
     ref.log('\x1b[36m%s\x1b[0m','adding step \"' + name + '\" to \"' + image + '\".');
 
-    o = ref.copy(o_);
+    var o = ref.copy(o_);
     o.id = ref.options.sequencerCounter++; //Gives a Unique ID to each step
     o.name = o_.name || name;
     o.selector = o_.selector || 'ismod-' + name;

--- a/src/FormatInput.js
+++ b/src/FormatInput.js
@@ -15,7 +15,7 @@ function copy(a) {
   if (objTypeOf(a) == "Array") return a.slice();
   if (objTypeOf(a) == "Object") {
     var b = {};
-    for (v in a) {
+    for (var v in a) {
       b[v] = copy(a[v]);
     }
     return b;
@@ -25,11 +25,11 @@ function copy(a) {
 
 function formatInput(args,format,images) {
   images = [];
-  for (image in this.images) {
+  for (var image in this.images) {
     images.push(image);
   }
-  json_q = {};
-  format_i = format;
+  var json_q = {};
+  var format_i = format;
   if (format == "+")
     format = ['o_string_a', 'string_a', 'o_object'];
   else if (format == "-")
@@ -76,8 +76,8 @@ function formatInput(args,format,images) {
 
   if(format[0] == "o_string_a") {
     if(args.length == format.length - 1) {
-      insert = false;
-      for (i in args) {
+      var insert = false;
+      for (var i in args) {
         if (format[parseInt(i)+1].includes( typeof(getPrimitive(args[i])) )){
           insert = true;
         }
@@ -89,15 +89,15 @@ function formatInput(args,format,images) {
   }
   else if (format[0] == "o_string" && format_i == "l" && args.length == 2) {
     if (typeof(args[0]) == "string") {
-      identifier = "image";
-      number = 1;
+      var identifier = "image";
+      var number = 1;
       while (this.images.hasOwnProperty(identifier+number)) number++;
       args.splice(0,0,identifier+number);
     }
   }
 
   if(args.length == format.length) {
-    for (i in format) {
+    for (var i in format) {
       if (format[i].substr(format[i].length-2,2)=="_a")
         args[i] = makeArray(args[i]);
     }
@@ -106,12 +106,12 @@ function formatInput(args,format,images) {
   if (args.length == 1) {
     json_q = copy(args[0]);
     if(!(format_i == "r" || format_i == "l")) {
-      for (img in json_q)
+      for (var img in json_q)
         json_q[img] = makeArray(json_q[img]);
     }
   }
   else if (format_i == "r") {
-    for (img in args[0]) json_q[args[0][img]] = args[1];
+    for (var img in args[0]) json_q[args[0][img]] = args[1];
   }
   else if (format_i == "l") {
     json_q = {
@@ -121,12 +121,12 @@ function formatInput(args,format,images) {
     json_q.images[args[0]] = args[1];
   }
   else {
-    for (img in args[0]) {
-      image = args[0][img];
+    for (var img in args[0]) {
+      var image = args[0][img];
       json_q[image] = [];
 
       if(format_i == "+") {
-        for(s in args[1]) {
+        for(var s in args[1]) {
           json_q[image].push({
             name: args[1][s],
             o: args[2]
@@ -139,8 +139,8 @@ function formatInput(args,format,images) {
       }
 
       if(format_i == "^") {
-        size = this.images[image].steps.length;
-        index = args[1];
+        var size = this.images[image].steps.length;
+        var index = args[1];
         index = (index==size)?index:index%size;
         if (index<0) index += size+1;
         json_q[image].push({
@@ -155,7 +155,7 @@ function formatInput(args,format,images) {
 
   if(format_i == "l") {
     json_q.loadedimages = [];
-    for (i in json_q.images) json_q.loadedimages.push(i);
+    for (var i in json_q.images) json_q.loadedimages.push(i);
   }
 
   return json_q;

--- a/src/ImageSequencer.js
+++ b/src/ImageSequencer.js
@@ -24,7 +24,7 @@ ImageSequencer = function ImageSequencer(options) {
     if (objTypeOf(a) == "Array") return a.slice();
     if (objTypeOf(a) == "Object") {
       var b = {};
-      for (v in a) {
+      for (var v in a) {
         b[v] = copy(a[v]);
       }
       return b;
@@ -36,11 +36,10 @@ ImageSequencer = function ImageSequencer(options) {
     return (objTypeOf(input)=="Array")?input:[input];
   }
 
-  formatInput = require('./FormatInput');
-
   var image,
       steps = [],
       modules = require('./Modules'),
+      formatInput = require('./FormatInput'),
       images = {},
       inputlog = [];
 
@@ -50,15 +49,15 @@ ImageSequencer = function ImageSequencer(options) {
 
   function addSteps(){
     const this_ = (this.name == "ImageSequencer")?this:this.sequencer;
-    args = (this.name == "ImageSequencer")?[]:[this.images];
-    json_q = {};
-    for(arg in arguments){args.push(copy(arguments[arg]));}
+    var args = (this.name == "ImageSequencer")?[]:[this.images];
+    var json_q = {};
+    for(var arg in arguments){args.push(copy(arguments[arg]));}
     json_q = formatInput.call(this_,args,"+");
 
     inputlog.push({method:"addSteps", json_q:copy(json_q)});
 
-    for (i in json_q)
-      for (j in json_q[i])
+    for (var i in json_q)
+      for (var j in json_q[i])
         require("./AddStep")(this_,i,json_q[i][j].name,json_q[i][j].o);
 
     return this;
@@ -74,18 +73,18 @@ ImageSequencer = function ImageSequencer(options) {
   }
 
   function removeSteps(image,index) {
-    run = {};
+    var run = {}, indices;
     const this_ = (this.name == "ImageSequencer")?this:this.sequencer;
-    args = (this.name == "ImageSequencer")?[]:[this.images];
-    for(arg in arguments) args.push(copy(arguments[arg]));
+    var args = (this.name == "ImageSequencer")?[]:[this.images];
+    for(var arg in arguments) args.push(copy(arguments[arg]));
 
-    json_q = formatInput.call(this_,args,"-");
+    var json_q = formatInput.call(this_,args,"-");
     inputlog.push({method:"removeSteps", json_q:copy(json_q)});
 
-    for (img in json_q) {
+    for (var img in json_q) {
       indices = json_q[img].sort(function(a,b){return b-a});
       run[img] = indices[indices.length-1];
-      for (i in indices)
+      for (var i in indices)
         removeStep(img,indices[i]);
     }
     // this.run(run); // This is creating problems
@@ -93,18 +92,18 @@ ImageSequencer = function ImageSequencer(options) {
   }
 
   function insertSteps(image, index, name, o) {
-    run = {};
+    var run = {};
     const this_ = (this.name == "ImageSequencer")?this:this.sequencer;
-    args = (this.name == "ImageSequencer")?[]:[this.images];
-    for (arg in arguments) args.push(arguments[arg]);
+    var args = (this.name == "ImageSequencer")?[]:[this.images];
+    for (var arg in arguments) args.push(arguments[arg]);
 
-    json_q = formatInput.call(this_,args,"^");
+    var json_q = formatInput.call(this_,args,"^");
     inputlog.push({method:"insertSteps", json_q:copy(json_q)});
 
-    for (img in json_q) {
+    for (var img in json_q) {
       var details = json_q[img];
       details = details.sort(function(a,b){return b.index-a.index});
-      for (i in details)
+      for (var i in details)
         require("./InsertStep")(this_,img,details[i].index,details[i].name,details[i].o);
       run[img] = details[details.length-1].index;
     }
@@ -115,15 +114,15 @@ ImageSequencer = function ImageSequencer(options) {
   function run(t_image,t_from) {
     log('\x1b[32m%s\x1b[0m',"Running the Sequencer!");
     const this_ = (this.name == "ImageSequencer")?this:this.sequencer;
-    args = (this.name == "ImageSequencer")?[]:[this.images];
+    var args = (this.name == "ImageSequencer")?[]:[this.images];
     for (var arg in arguments) args.push(copy(arguments[arg]));
 
-    callback = function() {};
+    var callback = function() {};
     for (var arg in args)
       if(objTypeOf(args[arg]) == "Function")
         callback = args.splice(arg,1)[0];
 
-    json_q = formatInput.call(this_,args,"r");
+    var json_q = formatInput.call(this_,args,"r");
 
     require('./Run')(this_, json_q, callback);
 
@@ -131,14 +130,14 @@ ImageSequencer = function ImageSequencer(options) {
   }
 
   function loadImages() {
-    args = [];
-    for (arg in arguments) args.push(copy(arguments[arg]));
-    json_q = formatInput.call(this,args,"l");
+    var args = [];
+    for (var arg in arguments) args.push(copy(arguments[arg]));
+    var json_q = formatInput.call(this,args,"l");
 
     inputlog.push({method:"loadImages", json_q:copy(json_q)});
-    loadedimages = this.copy(json_q.loadedimages);
+    var loadedimages = this.copy(json_q.loadedimages);
 
-    for (i in json_q.images)
+    for (var i in json_q.images)
       require('./LoadImage')(this,i,json_q.images[i])
 
     json_q.callback();

--- a/src/InsertStep.js
+++ b/src/InsertStep.js
@@ -3,7 +3,7 @@ function InsertStep(ref, image, index, name, o) {
   function insertStep(image, index, name, o_) {
     ref.log('\x1b[36m%s\x1b[0m','inserting step \"' + name + '\" to \"' + image + '\" at \"'+index+'\".');
 
-    o = ref.copy(o_);
+    var o = ref.copy(o_);
     o.id = ref.options.sequencerCounter++; //Gives a Unique ID to each step
     o.name = o.name || name;
     o.selector = o.selector || 'ismod-' + name;

--- a/src/LoadImage.js
+++ b/src/LoadImage.js
@@ -1,7 +1,7 @@
 function LoadImage(ref, name, src) {
   function CImage(src) {
-    datauri = (ref.options.inBrowser || src.substring(0,11) == "data:image/")?(src):require('urify')(src);
-    image = {
+    var datauri = (ref.options.inBrowser || src.substring(0,11) == "data:image/")?(src):require('urify')(src);
+    var image = {
       src: datauri,
       format: datauri.split(':')[1].split(';')[0].split('/')[1]
     }
@@ -9,7 +9,7 @@ function LoadImage(ref, name, src) {
   }
 
   function loadImage(name, src) {
-    image = {
+    var image = {
       src: src,
       steps: [{
         options: {

--- a/src/ReplaceImage.js
+++ b/src/ReplaceImage.js
@@ -1,12 +1,12 @@
 function ReplaceImage(ref,selector,steps,options) {
   if(!ref.options.inBrowser) return false; // This isn't for Node.js
-  this_ = ref;
+  var this_ = ref;
   var input = document.querySelectorAll(selector);
   var images = [];
-  for (i = 0; i < input.length; i++)
+  for (var i = 0; i < input.length; i++)
     if (input[i] instanceof HTMLImageElement) images.push(input[i]);
-  for (i in images) {
-    the_image = images[i];
+  for (var i in images) {
+    var the_image = images[i];
     var url = images[i].src;
     var ext = url.split('.').pop();
 

--- a/src/Run.js
+++ b/src/Run.js
@@ -1,47 +1,47 @@
 function Run(ref, json_q, callback) {
   function drawStep(drawarray,pos) {
     if(pos==drawarray.length) {
-      image = drawarray[pos-1].image;
+      var image = drawarray[pos-1].image;
       if(ref.objTypeOf(callback)=='Function'){
-        steps = ref.images[image].steps;
-        out = steps[steps.length-1].output.src;
+        var steps = ref.images[image].steps;
+        var out = steps[steps.length-1].output.src;
         callback(out);
         return true;
       }
     }
-    image = drawarray[pos].image;
-    i = drawarray[pos].i;
-    input = ref.images[image].steps[i-1].output;
+    var image = drawarray[pos].image;
+    var i = drawarray[pos].i;
+    var input = ref.images[image].steps[i-1].output;
     ref.images[image].steps[i].draw(ref.copy(input),function(){
       drawStep(drawarray,++pos);
     });
   }
   function drawSteps(json_q) {
-    drawarray = [];
-    for (image in json_q) {
-      no_steps = ref.images[image].steps.length;
-      init = json_q[image];
-      for(i = 0; i < no_steps-init; i++) {
+    var drawarray = [];
+    for (var image in json_q) {
+      var no_steps = ref.images[image].steps.length;
+      var init = json_q[image];
+      for(var i = 0; i < no_steps-init; i++) {
         drawarray.push({image: image,i: init+i});
       }
     }
     drawStep(drawarray,0);
   }
   function filter(json_q){
-    for (image in json_q) {
+    for (var image in json_q) {
       if (json_q[image]==0 && ref.images[image].steps.length==1)
         delete json_q[image];
       else if (json_q[image]==0) json_q[image]++;
     }
-    for (image in json_q) {
-      prevstep = ref.images[image].steps[json_q[image]-1];
+    for (var image in json_q) {
+      var prevstep = ref.images[image].steps[json_q[image]-1];
       while (typeof(prevstep) == "undefined" || typeof(prevstep.output) == "undefined") {
         prevstep = ref.images[image].steps[(--json_q[image]) - 1];
       }
     }
     return json_q;
   }
-  json_q = filter(json_q);
+  var json_q = filter(json_q);
   return drawSteps(json_q);
 }
 module.exports = Run;

--- a/src/modules/Crop/Module.js
+++ b/src/modules/Crop/Module.js
@@ -16,7 +16,7 @@
  module.exports = function CropModule(options) {
    options = options || {};
    options.title = "Crop Image";
-   this_ = this;
+   var this_ = this;
    var output
 
    function draw(input,callback) {

--- a/src/modules/DoNothing/Module.js
+++ b/src/modules/DoNothing/Module.js
@@ -4,7 +4,7 @@
 module.exports = function DoNothing(options) {
   options = options || {};
   options.title = "Do Nothing";
-  this_ = this;
+  var this_ = this;
   var output
 
   function draw(input,callback) {

--- a/src/modules/DoNothingPix/Module.js
+++ b/src/modules/DoNothingPix/Module.js
@@ -8,7 +8,7 @@ module.exports = function DoNothingPix(options) {
   var output;
 
   function draw(input,callback) {
-    this_ = this;
+    var this_ = this;
     function changePixel(r, g, b, a) {
       return [r, g, b, a];
     }

--- a/src/modules/GreenChannel/Module.js
+++ b/src/modules/GreenChannel/Module.js
@@ -11,7 +11,7 @@ module.exports = function GreenChannel(options) {
   //function setup() {} // optional
 
   function draw(input,callback) {
-    this_ = this;
+    var this_ = this;
     function changePixel(r, g, b, a) {
       return [0, g, 0, a];
     }

--- a/src/modules/Invert/Module.js
+++ b/src/modules/Invert/Module.js
@@ -11,7 +11,7 @@ module.exports = function GreenChannel(options) {
   //function setup() {} // optional
 
   function draw(input,callback) {
-    this_ = this;
+    var this_ = this;
     function changePixel(r, g, b, a) {
       return [255-r, 255-g, 255-b, a];
     }

--- a/src/modules/NdviRed/Module.js
+++ b/src/modules/NdviRed/Module.js
@@ -8,7 +8,7 @@ module.exports = function NdviRed(options) {
   var output;
 
   function draw(input,callback) {
-    this_ = this;
+    var this_ = this;
     function changePixel(r, g, b, a) {
       var ndvi = (b - r) / (1.00 * b + r);
       var x = 255 * (ndvi + 1) / 2;

--- a/src/modules/SegmentedColormap/Module.js
+++ b/src/modules/SegmentedColormap/Module.js
@@ -5,7 +5,7 @@ module.exports = function SegmentedColormap(options) {
   var output;
 
   function draw(input,callback) {
-    this_ = this;
+    var this_ = this;
     function changePixel(r, g, b, a) {
       var ndvi = (b - r) / (r + b);
       var normalized = (ndvi + 1) / 2;

--- a/test/image-sequencer.js
+++ b/test/image-sequencer.js
@@ -8,6 +8,23 @@ var test = require('tape');
 
 require('../src/ImageSequencer.js');
 
+// This function is used to test whether or not any additional global variables are being created
+function copy(g,a) {
+  var b = {};
+  var i = 0;
+  for (var v in a)
+    if(g) {
+      if(v != "sequencer") b[v] = a[v];
+    }
+    else {
+      if(v != "sequencer" && v!="global1" && v!="global2" && !global1.hasOwnProperty(v)) i++;
+    }
+  if(g) return b;
+  else return i;
+}
+var parent = (typeof(global)==="undefined")?window:global;
+var global1 = copy(true,parent);
+
 var sequencer = ImageSequencer({ ui: "none" });
 var red = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAAQABADASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAABgj/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABykX//Z";
 
@@ -136,5 +153,11 @@ test('run() runs the sequencer and returns output to callback', function (t) {
 test('replaceImage returns false in NodeJS', function (t) {
   var returnvalue = (sequencer.options.inBrowser)?false:sequencer.replaceImage("#selector","test");
   t.equal(returnvalue,false,"It does.");
+  t.end();
+});
+
+var global2 = copy(false,parent);
+test('No Global Variables Created', function (t) {
+  t.equal(0,global2,"None Created.");
   t.end();
 });


### PR DESCRIPTION
While making a demo, I realized that ImageSequencer was producing 22 Global Variables:
`v`,`formatInput`,`args`,`arg`,`json_q`,`format_i`,`i`,`loadedimages`,`datauri`,`image`,`insert`,`img`,`s`,`j`,`indices`,`callback`,`prevstep`,`drawarray`,`no_steps`,`init`,`input`,`this_`.

I have fixed this issue and created a new Unit test to check that no Global Variables are being created.