### PR TITLE
Remove base64-stream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "urify": "^2.1.0"
   },
   "devDependencies": {
-    "base64-stream": "~0.1.3",
     "browserify": "13.0.0",
     "buffer": "~5.0.2",
     "get-pixels": "~3.3.0",

--- a/src/modules/Crop/Crop.js
+++ b/src/modules/Crop/Crop.js
@@ -1,17 +1,15 @@
 module.exports = function Crop(input,options,callback) {
 
-  var getPixels = require("get-pixels"),
-      savePixels = require("save-pixels"),
-      base64 = require('base64-stream');
+  var getPixels = require('get-pixels'),
+      savePixels = require('save-pixels');
 
   getPixels(input.src,function(err,pixels){
-    var newdata = [];
     var ox = options.x || 0;
     var oy = options.y || 0;
     var w = options.w || Math.floor(0.5*pixels.shape[0]);
     var h = options.h || Math.floor(0.5*pixels.shape[1]);
     var iw = pixels.shape[0]; //Width of Original Image
-    newarray = new Uint8Array(4*w*h);
+    var newarray = new Uint8Array(4*w*h);
     for (var n = oy; n < oy + h; n++) {
       newarray.set(pixels.data.slice(n*4*iw + ox, n*4*iw + ox + 4*w),4*w*(n-oy));
     }
@@ -19,15 +17,19 @@ module.exports = function Crop(input,options,callback) {
     pixels.shape = [w,h,4];
     pixels.stride[1] = 4*w;
 
-    options.format = "jpeg";
-
-    w = base64.encode();
+    var chunks = [];
+    var totalLength = 0;
     var r = savePixels(pixels, options.format);
-    r.pipe(w).on('finish',function(){
-      data = w.read().toString();
-      datauri = 'data:image/' + options.format + ';base64,' + data;
+
+    r.on('data', function(chunk){
+      totalLength += chunk.length;
+      chunks.push(chunk);
+    });
+
+    r.on('end', function(){
+      var data = Buffer.concat(chunks, totalLength).toString('base64');
+      var datauri = 'data:image/' + options.format + ';base64,' + data;
       callback(datauri,options.format);
     });
   });
-
-}
+};


### PR DESCRIPTION
This is an attempt to fix #31.

Currently as mentioned in the issue description the workflow is:

- savePixels() generates a readable stream -- r
- base64-stream generates a writable stream -- w
- r.pipe(w) pipes r to w
- a listener for the 'finish' event is attached to the pipe which is responsible for converting the image data to a DataURI.

Again as mentioned in the issue description it seems that the 'finish' event is not emitted.

This probably happens as a consequence of backpressure handling. The write queue of the transform stream (`w`) is filled so no more data is read from the source (`r`) until the [`'drain'`](https://nodejs.org/dist/latest/docs/api/stream.html#stream_event_drain) event is emitted but this never happens because no one is reading from the readable side of `w`.

This also explains why it work with a small 16x16 image. If the image is smaller than `highWaterMark` which defaults to 16384 bytes, then the `'finish'` event should always be emitted.

A possible fix was to add a listener for the `'data'` event to `w`, save all data chunks and merge them on `'finish'`.

This patch saves and merges all data chunks but also removes the `base64-stream` dependency. Conversion to base64 is done after all chunks are concatenated and using the built-in `buf.toString('base64')` method.