### PR TITLE
Added Metadata

### DIFF
--- a/src/AddStep.js
+++ b/src/AddStep.js
@@ -8,6 +8,16 @@ function AddStep(ref, image, name, o) {
     o.container = o_.container || ref.options.selector;
     o.image = image;
 
+    var metadata = ref.images[image].metadata;
+    if(!metadata.hasOwnProperty(name)) {
+      metadata[name] = [];
+      metadata[name].last = function() {
+        return this[this.length-1];
+      }
+    }
+    metadata[name].push({});
+    o.metadata = metadata[name].last();
+
     var UI = ref.UI({
       stepName: o.name,
       stepID: o.number,

--- a/src/InsertStep.js
+++ b/src/InsertStep.js
@@ -10,6 +10,16 @@ function InsertStep(ref, image, index, name, o) {
 
     if(index==-1) index = ref.images[image].steps.length;
 
+    var metadata = ref.images[image].metadata;
+    if(!metadata.hasOwnProperty(name)) {
+      metadata[name] = [];
+      metadata[name].last = function() {
+        return this[this.length-1];
+      }
+    }
+    metadata[name].push({});
+    o.metadata = metadata[name].last();
+
     var UI = ref.UI({
       stepName: o.name,
       stepID: o.number,

--- a/src/LoadImage.js
+++ b/src/LoadImage.js
@@ -11,6 +11,7 @@ function LoadImage(ref, name, src) {
   function loadImage(name, src) {
     var image = {
       src: src,
+      metadata: {},
       steps: [{
         options: {
           id: ref.options.sequencerCounter++,
@@ -37,6 +38,14 @@ function LoadImage(ref, name, src) {
         output: CImage(src)
       }]
     };
+    image.metadata['load-image'] = [{
+      name: name,
+      src: src,
+      format: image.steps[0].output.format
+    }];
+    image.metadata['load-image'].last = function() {
+      return this[this.length-1];
+    }
     ref.images[name] = image;
     ref.images[name].steps[0].UI.onSetup();
     ref.images[name].steps[0].UI.onDraw();

--- a/src/modules/Crop/Crop.js
+++ b/src/modules/Crop/Crop.js
@@ -9,6 +9,7 @@ module.exports = function Crop(input,options,callback) {
     var w = options.w || Math.floor(0.5*pixels.shape[0]);
     var h = options.h || Math.floor(0.5*pixels.shape[1]);
     var iw = pixels.shape[0]; //Width of Original Image
+    var ih = pixels.shape[1]; //Height of Original Image
     var newarray = new Uint8Array(4*w*h);
     for (var n = oy; n < oy + h; n++) {
       newarray.set(pixels.data.slice(n*4*iw + ox, n*4*iw + ox + 4*w),4*w*(n-oy));
@@ -16,6 +17,12 @@ module.exports = function Crop(input,options,callback) {
     pixels.data = newarray;
     pixels.shape = [w,h,4];
     pixels.stride[1] = 4*w;
+
+    Object.assign(options.metadata,{
+      x:ox,y:oy,w:w,h:h,original_w:iw,original_h:ih
+    });
+
+    options.format = input.format;
 
     var chunks = [];
     var totalLength = 0;

--- a/src/modules/Crop/Module.js
+++ b/src/modules/Crop/Module.js
@@ -17,7 +17,7 @@
    options = options || {};
    options.title = "Crop Image";
    UI.onSetup();
-   var output
+   var output;
 
    function draw(input,callback) {
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,0 @@
-require('./src/ImageSequencer');
-sequencer = ImageSequencer();
-sequencer.loadImages({images:{red:'examples/red.jpg'},callback:function(){
-  sequencer.addSteps(['do-nothing','invert']).run();
-}});


### PR DESCRIPTION
I have added the `metadata` object as discussed in #70 
It lives as `sequencer.images.${image-name}.metadata`

This is how the metadata object looks like :

```js
var metadata = {
    'load-image': [ {first-repetition}, {second-repetition}, ... ],
    'crop': [ {first-repetition}, {second-repetition}, ... ],
    ...
}
```

The Metadata for every module is an array. That is because a module may be applied multiple times, and it isn't a nice idea to lose the previous metadata every time this happens. (This discussion was still ongoing in #70 while I was making this and hence, this isn't final. This is still just a draft.)

For simplicity, I have implemented a method `last` to all such "metadata arrays". That is,
`sequencer.images.image1.metadata['crop'].last()` will return the metadata of the last repetition of crop. This was necessary because the most-used repetition would be the last one, but we still must store the previous ones. (I am not sure if implementing new methods like this is a good practice, I'd like to know what you think about this)

A metadata object is created for every step added and the reference of this object is passed to the module when it is added in the form of `options.metadata`. So to set the metadata properties *from the module*, the following can be done:

```js
options.metadata.key = value;
```

I have added some basic metadata properties to two modules - for verification purposes:
* load-image : name, src, format
* crop : x, y, w, h, original_w, original_h