### PR TITLE
resolves #132 fix options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Image Sequencer also provides a CLI for applying operations to local files. The 
     -s  | --step [step-name] | Name of the step to be added. (required)
     -b  | --basic            | Basic mode only outputs the final image
     -o  | --output [PATH]    | Directory where output will be stored. (optional)
-    -d | --details {object}  | Options for the step. (optional)
+    -d  | --details {object} | Options for the step. (optional)
 
 The basic format for using the CLI is as follows: 
 
@@ -121,7 +121,7 @@ Options for the steps can be passed in one line as json in the details option li
 $ ./index.js -i [PATH] -s "brightness" -d '{"brightness":50}'
 
 ```
-else values will be taken through terminal prompt like
+Or the values can be given through terminal prompt like
 
 <img width="1436" alt="screen shot 2018-02-14 at 5 18 50 pm" src="https://user-images.githubusercontent.com/25617855/36202790-3c6e8204-11ab-11e8-9e17-7f3387ab0158.png">
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Image Sequencer also provides a CLI for applying operations to local files. The 
     -s  | --step [step-name] | Name of the step to be added. (required)
     -b  | --basic            | Basic mode only outputs the final image
     -o  | --output [PATH]    | Directory where output will be stored. (optional)
-    -op | --opions {object}  | Options for the step. (optional)
+    -d | --details {object}  | Options for the step. (optional)
 
 The basic format for using the CLI is as follows: 
 
@@ -115,6 +115,15 @@ The CLI also can take multiple steps at once, like so:
 ```
 
 But for this, double quotes must wrap the space-separated steps.
+
+Options for the steps can be passed in one line as json in the details option like 
+```
+$ ./index.js -i [PATH] -s "brightness" -d '{"brightness":50}'
+
+```
+else values will be taken through terminal prompt like
+
+<img width="1436" alt="screen shot 2018-02-14 at 5 18 50 pm" src="https://user-images.githubusercontent.com/25617855/36202790-3c6e8204-11ab-11e8-9e17-7f3387ab0158.png">
 
 ## Classic Usage
 

--- a/index.js
+++ b/index.js
@@ -12,13 +12,13 @@ function exit(message) {
 }
 
 program
-  .version('0.1.0')
-  .option('-i, --image [PATH/URL]', 'Input image URL')
-  .option('-s, --step [step-name]', 'Name of the step to be added.')
-  .option('-o, --output [PATH]', 'Directory where output will be stored.')
-  .option('-b, --basic','Basic mode outputs only final image')
-  .option('-op, --opions {object}', 'Options for the step')
-  .parse(process.argv);
+.version('0.1.0')
+.option('-i, --image [PATH/URL]', 'Input image URL')
+.option('-s, --step [step-name]', 'Name of the step to be added.')
+.option('-o, --output [PATH]', 'Directory where output will be stored.')
+.option('-b, --basic','Basic mode outputs only final image')
+.option('-d, --details [Object]', 'Options for the step')
+.parse(process.argv);
 
 // Parse step into an array to allow for multiple steps.
 if(!program.step) exit("No steps passed")
@@ -34,79 +34,97 @@ require('fs').access(program.image, function(err){
 
 // User must input a step. If steps exist, check that every step is a valid step.
 if(!program.step || !validateSteps(program.step))
-  exit("Please ensure all steps are valid.");
+exit("Please ensure all steps are valid.");
 
 // If there's no user defined output directory, select a default directory.
 program.output = program.output || "./output/";
 
 // Set sequencer to log module outputs, if any.
 sequencer.setUI({
-
+  
   onComplete: function(step) {
-
+    
     // Get information of outputs.
     step.info = sequencer.modulesInfo(step.name);
-
+    
     for (var output in step.info.outputs) {
       console.log("["+program.step+"]: "+output+" = "+step[output]);
     }
-
+    
   }
-
+  
 });
 
 // Finally, if everything is alright, load the image, add the steps and run the sequencer.
 sequencer.loadImages(program.image,function(){
-    console.warn('\x1b[33m%s\x1b[0m', "The execution will be async\nYou may not see the output for a few seconds or minutes")
-
-    //Generate the Output Directory
-    require('./src/CliUtils').makedir(program.output,()=>{
-      console.log("Files will be exported to \""+program.output+"\"");
-
-      if(program.basic) console.log("Basic mode is enabled, outputting only final image")
-
-  // Iterate through the steps and retrieve their inputs.
-  program.step.forEach(function(step){
-    var options = Object.assign({}, sequencer.modulesInfo(step).inputs);
-
-    // If inputs exists, print to console.
-    if (Object.keys(options).length) {
-      console.log("[" + step + "]: Inputs");
-    }
-
-    // If inputs exists, print them out with descriptions.
-    Object.keys(options).forEach(function(input) {
+  console.warn('\x1b[33m%s\x1b[0m', "The execution will be async\nYou may not see the output for a few seconds or minutes")
+  
+  //Generate the Output Directory
+  require('./src/CliUtils').makedir(program.output,()=>{
+    console.log("Files will be exported to \""+program.output+"\"");
+    
+    if(program.basic) console.log("Basic mode is enabled, outputting only final image")
+    
+    // Iterate through the steps and retrieve their inputs.
+    program.step.forEach(function(step){
+      var options = Object.assign({}, sequencer.modulesInfo(step).inputs);
+      
+      // If inputs exists, print to console.
+      if (Object.keys(options).length) {
+        console.log("[" + step + "]: Inputs");
+      }
+      
+      // If inputs exists, print them out with descriptions.
+      Object.keys(options).forEach(function(input) {
         // The array below creates a variable number of spaces. This is done with (length + 1). 
         // The extra 4 that makes it (length + 5) is to account for the []: characters
         console.log(new Array(step.length + 5).join(' ') + input + ": " + options[input].desc);
+      });
+      
+      if(program.details){
+        try{
+          program.details = JSON.parse(program.details);
+          console.log(`The parsed options object: `, program.details);
+        }
+        catch(e){
+          console.error('\x1b[31m%s\x1b[0m',`Options(Details) is not a not valid JSON Fallback activate`);
+          program.details = false;
+          console.log(e);
+        }
+      }
+      if(program.details && validateDetails(program.details,options)){
+        console.log("Now using Options object");
+        Object.keys(options).forEach(function (input) {
+          options[input] = program.details[input];
+        })
+      }
+      else{
+        // If inputs exist, iterate through them and prompt for values.
+        Object.keys(options).forEach(function(input) {
+          var value = readlineSync.question("[" + step + "]: Enter a value for " + input + " (" + options[input].type + ", default: " + options[input].default + "): ");
+          options[input] = value;
+        });
+      }
+      // Add the step and its inputs to the sequencer.
+      sequencer.addSteps(step, options);
     });
-
-    // If inputs exist, iterate through them and prompt for values.
-    Object.keys(options).forEach(function(input) {
-        var value = readlineSync.question("[" + step + "]: Enter a value for " + input + " (" + options[input].type + ", default: " + options[input].default + "): ");
-        options[input] = value;
+    
+    // Run the sequencer.
+    sequencer.run(function(){
+      
+      // Export all images or final image as binary files.
+      sequencer.exportBin(program.output,program.basic);
+      
+      
     });
-
-    // Add the step and its inputs to the sequencer.
-    sequencer.addSteps(step, options);
+    
   });
-
-  // Run the sequencer.
-  sequencer.run(function(){
-
-    // Export all images or final image as binary files.
-    sequencer.exportBin(program.output,program.basic);
-
-
-  });
-
-    });
-
+  
 });
 
 // Takes an array of steps and checks if they are valid steps for the sequencer.
- function validateSteps(steps) {
-
+function validateSteps(steps) {
+  
   // Assume all are valid in the beginning. 
   var valid = true;
   steps.forEach(function(step) {
@@ -115,7 +133,25 @@ sequencer.loadImages(program.image,function(){
       valid = false;
     }
   });
-
+  
   // Return valid. (If all of the steps are valid properties, valid will have remained true).
   return valid;
+}
+
+//Takes details and options object and checks if all the keys exist in details 
+function validateDetails(details_,options_){
+  options_ = Object.keys(options_);
+  if (
+    (function(){
+    for(var input in options_){
+      if(!details_[options_[input]]){
+        console.error('\x1b[31m%s\x1b[0m',`Options Object does not have the required details "${options_[input]}" not specified. Fallback case activated`);
+        return false;
+      } 
+    }
+  })()
+   == false)
+     return false;
+  else
+     return true;
 }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ program
 .option('-s, --step [step-name]', 'Name of the step to be added.')
 .option('-o, --output [PATH]', 'Directory where output will be stored.')
 .option('-b, --basic','Basic mode outputs only final image')
-.option('-d, --details [Object]', 'Options for the step')
+.option('-c, --config [Object]', 'Options for the step')
 .parse(process.argv);
 
 // Parse step into an array to allow for multiple steps.
@@ -81,21 +81,21 @@ sequencer.loadImages(program.image,function(){
         console.log(new Array(step.length + 5).join(' ') + input + ": " + options[input].desc);
       });
       
-      if(program.details){
+      if(program.config){
         try{
-          program.details = JSON.parse(program.details);
-          console.log(`The parsed options object: `, program.details);
+          program.config = JSON.parse(program.config);
+          console.log(`The parsed options object: `, program.config);
         }
         catch(e){
-          console.error('\x1b[31m%s\x1b[0m',`Options(Details) is not a not valid JSON Fallback activate`);
-          program.details = false;
+          console.error('\x1b[31m%s\x1b[0m',`Options(Config) is not a not valid JSON Fallback activate`);
+          program.config = false;
           console.log(e);
         }
       }
-      if(program.details && validateDetails(program.details,options)){
+      if(program.config && validateConfig(program.config,options)){
         console.log("Now using Options object");
         Object.keys(options).forEach(function (input) {
-          options[input] = program.details[input];
+          options[input] = program.config[input];
         })
       }
       else{
@@ -138,13 +138,13 @@ function validateSteps(steps) {
   return valid;
 }
 
-//Takes details and options object and checks if all the keys exist in details 
-function validateDetails(details_,options_){
+//Takes config and options object and checks if all the keys exist in config 
+function validateConfig(config_,options_){
   options_ = Object.keys(options_);
   if (
     (function(){
     for(var input in options_){
-      if(!details_[options_[input]]){
+      if(!config_[options_[input]]){
         console.error('\x1b[31m%s\x1b[0m',`Options Object does not have the required details "${options_[input]}" not specified. Fallback case activated`);
         return false;
       } 


### PR DESCRIPTION
- Renamed the --options object to --details object since -op would be read as -o and -p -o being the output directory, now -d can be used to pass details of the inputs of steps as json
`sequencer -i 'ImagePath' -s  "brightness" -d '{"brightness":200}'`

- Also handled fallback cases if the data passed is not valid json or does not contain the necessary information
**PS** the code immediately falls back to readlineSync if any of the above cases is encountered
@jywarren please have a look