### PR TITLE
#363 Add placeholder option to input

### DIFF
--- a/examples/lib/defaultHtmlStepUi.js
+++ b/examples/lib/defaultHtmlStepUi.js
@@ -71,6 +71,8 @@ function DefaultHtmlStepUi(_sequencer, options) {
             inputDesc.type +
             '" name="' +
             paramName +
+            '" placeholder ="' +
+            (inputDesc.placeholder || "") +
             '">';
         }
 

--- a/src/modules/Brightness/info.json
+++ b/src/modules/Brightness/info.json
@@ -5,7 +5,7 @@
       "brightness": {
           "type": "number",
           "desc": "% brightness for the new image",
-          "placeholder": "0%",
+          "placeholder": "0",
           "default": 0 
       }
   } 

--- a/src/modules/Brightness/info.json
+++ b/src/modules/Brightness/info.json
@@ -1,11 +1,12 @@
 {
-    "name": "Brightness",
-    "description": "Change the brightness of the image by given percent value",
-    "inputs": {
-        "brightness": {
-            "type": "integer",
-            "desc": "% brightness for the new image",
-            "default": 0 
-        }
-    } 
+  "name": "Brightness",
+  "description": "Change the brightness of the image by given percent value",
+  "inputs": {
+      "brightness": {
+          "type": "number",
+          "desc": "% brightness for the new image",
+          "placeholder": "0%",
+          "default": 0 
+      }
+  } 
 }


### PR DESCRIPTION
Add placeholder option to input. 
Change brightness input type to number.

 Changes to be committed:
	modified:   examples/lib/defaultHtmlStepUi.js
	modified:   src/modules/Brightness/info.json