### PR TITLE
enables Save button for an action when it is needed ( fixes #340 and #377 )

### DIFF
--- a/examples/lib/defaultHtmlStepUi.js
+++ b/examples/lib/defaultHtmlStepUi.js
@@ -100,7 +100,7 @@ function DefaultHtmlStepUi(_sequencer, options) {
         $(step.ui.querySelector("div.details .btn-save")).prop("disabled",false);
       }
 
-      $(step.ui.querySelector(".target")).change(toggleSaveButton);
+      $(step.ui.querySelectorAll(".target")).focus(toggleSaveButton);
 
       $(step.ui.querySelector("div.details")).append(
         "<p><button class='btn btn-default btn-save' disabled = 'true' >Save</button><span> Press save to see changes</span></p>"


### PR DESCRIPTION
Enables `Save` button for an action if any of its input fields gain focus, and keeps it disabled until then. Disables it once again when it is clicked, until one of the input elements for the action gain focus.