### PR TITLE
correctly regulates the behaviour of all links (fixes #386)

### DIFF
--- a/examples/lib/defaultHtmlStepUi.js
+++ b/examples/lib/defaultHtmlStepUi.js
@@ -45,7 +45,7 @@ function DefaultHtmlStepUi(_sequencer, options) {
     var parser = new DOMParser();
     step.ui = parser.parseFromString(step.ui, "text/html");
     step.ui = step.ui.querySelector("div.row");
-    step.linkElement = step.ui.querySelector("a");
+    step.linkElements = step.ui.querySelectorAll("a");
     step.imgElement = step.ui.querySelector("a img");
 
     if (_sequencer.modulesInfo().hasOwnProperty(step.name)) {
@@ -145,15 +145,21 @@ function DefaultHtmlStepUi(_sequencer, options) {
     $(step.ui.querySelector("img")).show();
 
     step.imgElement.src = step.output;
-    step.linkElement.href = step.output;
+    var imgthumbnail = step.ui.querySelector(".img-thumbnail");
+    for(let index=0; index < step.linkElements.length; index++) {
+      if(step.linkElements[index].contains(imgthumbnail))
+        step.linkElements[index].href = step.output;
+    }
 
     // TODO: use a generalized version of this
     function fileExtension(output) {
       return output.split("/")[1].split(";")[0];
     }
 
-    step.linkElement.download = step.name + "." + fileExtension(step.output);
-    step.linkElement.target = "_blank";
+    for(let index=0; index < step.linkElements.length; index++) {
+      step.linkElements[index].download = step.name + "." + fileExtension(step.output);
+      step.linkElements[index].target = "_blank";
+    }
 
     // fill inputs with stored step options
     if (_sequencer.modulesInfo().hasOwnProperty(step.name)) {


### PR DESCRIPTION
Signed-off-by: Ankit Singla <asingla590@gmail.com>
Fixes the issue where clicking the _Read more_ in the description of some modules led to image being downloaded.
While working on this, I also found that in the modules this was happening (Convolution, NDVI etc.), clicking on the image didn't result in download of the image, since the download was mapped to the _Read more_ link instead.
I found another issue where clicking a link in the description didn't result in it opening in a new tab, this PR also fixes that.

So, overall this PR regulates the behaviour of all links more appropriately.
@jywarren @tech4GT 