### PR TITLE
Added gif download modal

### DIFF
--- a/examples/demo.css
+++ b/examples/demo.css
@@ -134,6 +134,6 @@ h1 {
   display: block;
   margin: 0 auto;
   width: 100%;
-  height: 100%;
+  height: auto;
 }
 

--- a/examples/demo.css
+++ b/examples/demo.css
@@ -132,8 +132,8 @@ h1 {
 
 #gif_element {
   display: block;
-  padding: 50px;
   margin: 0 auto;
-
+  width: 100%;
+  height: 100%;
 }
 

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -29,7 +29,7 @@ window.onload = function() {
   $("#addStep #add-step-btn").on("click", ui.addStepUi);
   $('#addStep #download-btn').click(function() {
     $('img:last()').trigger( "click" );
- 
+
     return false;
     });
   $('body').on('click', 'button.remove', ui.removeStepUi);
@@ -38,6 +38,71 @@ window.onload = function() {
     sequencer.loadModules();
     refreshOptions();
   });
+
+  $('.js-view-as-gif').on('click', function(event) {
+    var button = event.target
+    button.disabled = true
+
+    // Select all images from previous steps
+    var imgs = document.getElementsByClassName("img-thumbnail")
+
+
+    var imgSrcs = [];
+
+    for (var i = 0; i < imgs.length; i++) {
+      imgSrcs.push(imgs[i].src);
+    }
+
+    var options = {
+      'gifWidth': 400,
+      'gifHeight': 350,
+      'images': imgSrcs,
+      'frameDuration': 7,
+    }
+
+    gifshot.createGIF(options, function(obj) {
+      if(!obj.error) {
+        var image = obj.image,
+        animatedImage = document.createElement('img');
+        animatedImage.src = image;
+        animatedImage.id = "gif_element";
+        var link = document.createElement('a');
+        var att1 = document.createAttribute("href");
+
+        var options = { type: 'image/gif' }
+
+        // Can't just set href attribute. Most gifs data are too big.
+        var gifBlob = new Blob([animatedImage.src], options)
+        var dataUrl = window.URL.createObjectURL(gifBlob, options)
+
+        att1.value = dataUrl;
+
+        var att2 = document.createAttribute("download");
+        att2.value = "index.gif";
+        link.setAttributeNode(att1);
+        link.setAttributeNode(att2);
+        link.appendChild(animatedImage);
+
+
+        var gifContainer = document.getElementById("js-download-modal-gif-container")
+        var gifButton = document.getElementById("js-download-as-gif-button")
+
+
+        gifButton.href = dataUrl
+
+        // Clear previous results
+        gifContainer.innerHTML = ''
+
+        // Insert image
+        gifContainer.appendChild(link);
+
+        // Trigger modal
+        $('#js-download-gif-modal').modal()
+        button.disabled = false
+
+      }
+    });
+  })
 
   // image selection and drag/drop handling from examples/lib/imageSelection.js
   sequencer.setInputStep({

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -53,9 +53,11 @@ window.onload = function() {
       imgSrcs.push(imgs[i].src);
     }
 
+
+
     var options = {
-      'gifWidth': 400,
-      'gifHeight': 350,
+      'gifWidth': imgs[0].width,
+      'gifHeight': imgs[0].height,
       'images': imgSrcs,
       'frameDuration': 7,
     }

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -27,11 +27,13 @@ window.onload = function() {
 
   $("#addStep select").on("change", ui.selectNewStepUi);
   $("#addStep #add-step-btn").on("click", ui.addStepUi);
-  $('#addStep #download-btn').click(function() {
-    $('img:last()').trigger( "click" );
+
+  $('#download-btn').click(function() {
+    $('.img-thumbnail:last()').trigger("click");
 
     return false;
-    });
+  });
+
   $('body').on('click', 'button.remove', ui.removeStepUi);
   $('#save-seq').click(() => {
     sequencer.saveSequence(window.prompt("Please give a name to your sequence..."), sequencer.toString());

--- a/examples/index.html
+++ b/examples/index.html
@@ -91,7 +91,7 @@
       <div class="form-inline">
         <div class="panel-body">
           <div style="text-align:center;">
-            <button class="btn btn-success btn-lg" id="download-btn" name="download">Download</button>
+            <button class="btn btn-success btn-lg" id="download-btn" name="download">Download PNG</button>
             <button class="btn btn-success btn-lg js-view-as-gif" id="gif">View Gif</button>
 
             <div class="modal fade" id="js-download-gif-modal" tabindex="-1" role="dialog">

--- a/examples/index.html
+++ b/examples/index.html
@@ -23,6 +23,9 @@
   <!-- for crop module: -->
   <script src="../node_modules/imgareaselect/jquery.imgareaselect.dev.js"></script>
   <script src="gifshot.js" type="text/javascript"></script>
+
+  <!-- Download.js for large files -->
+  <script src="../node_modules/downloadjs/download.min.js" type="text/javascript"/>
 </head>
 
 
@@ -106,7 +109,7 @@
                   <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">Done</button>
 
-                    <a id="js-download-as-gif-button" class="btn btn-primary" download="index.gif">Download</a>
+                    <button id="js-download-as-gif-button" class="btn btn-primary">Download</button>
                   </div>
                 </div>
               </div>

--- a/examples/index.html
+++ b/examples/index.html
@@ -90,6 +90,24 @@
           <div style="text-align:center;">
             <button class="btn btn-success btn-lg" id="download-btn" name="download">Download</button>
             <button class="btn btn-success btn-lg" onclick="create_gif()" id="gif">Download as Gif</button>
+            <div class="modal fade" id="download-gif-modal" tabindex="-1" role="dialog">
+              <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title">Your gif is ready</h4>
+                  </div>
+                  <div class="modal-body">
+                    <div id="download-modal-gif-container">
+                      <!-- Gif should appear here -->
+                    </div>
+                  </div>
+                  <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Done</button>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -103,15 +121,15 @@
       var sequencer;
     })
 
+
     function create_gif(){
-         
       var imgs = document.getElementsByTagName("img");
       var imgSrcs = [];
 
       for (var i = 0; i < imgs.length; i++) {
           imgSrcs.push(imgs[i].src);
       }
-    
+
       gifshot.createGIF({
         'gifWidth': 400,
         'gifHeight': 350,
@@ -132,16 +150,27 @@
           link.setAttributeNode(att1);
           link.setAttributeNode(att2);
           link.appendChild(animatedImage);
-          document.body.appendChild(link);
+
+
+          var gifContainer = document.getElementById("download-modal-gif-container")
+
+          // Clear previous results
+          gifContainer.innerHTML = ''
+
+          // Insert image
+          gifContainer.appendChild(link);
+
+          // Trigger modal
+          $('#download-gif-modal').modal()
           link.click();
         }
       });
 
    }
-    
-    
 
-    
+
+
+
   </script>
 
 </body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -89,8 +89,9 @@
         <div class="panel-body">
           <div style="text-align:center;">
             <button class="btn btn-success btn-lg" id="download-btn" name="download">Download</button>
-            <button class="btn btn-success btn-lg" onclick="create_gif()" id="gif">Download as Gif</button>
-            <div class="modal fade" id="download-gif-modal" tabindex="-1" role="dialog">
+            <button class="btn btn-success btn-lg js-view-as-gif" id="gif">View Gif</button>
+
+            <div class="modal fade" id="js-download-gif-modal" tabindex="-1" role="dialog">
               <div class="modal-dialog" role="document">
                 <div class="modal-content">
                   <div class="modal-header">
@@ -98,17 +99,20 @@
                     <h4 class="modal-title">Your gif is ready</h4>
                   </div>
                   <div class="modal-body">
-                    <div id="download-modal-gif-container">
+                    <div id="js-download-modal-gif-container">
                       <!-- Gif should appear here -->
                     </div>
                   </div>
                   <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">Done</button>
+
+                    <a id="js-download-as-gif-button" class="btn btn-primary" download="index.gif">Download</a>
                   </div>
                 </div>
               </div>
             </div>
           </div>
+
         </div>
       </div>
     </section>
@@ -120,57 +124,6 @@
     $(function() {
       var sequencer;
     })
-
-
-    function create_gif(){
-      var imgs = document.getElementsByTagName("img");
-      var imgSrcs = [];
-
-      for (var i = 0; i < imgs.length; i++) {
-          imgSrcs.push(imgs[i].src);
-      }
-
-      gifshot.createGIF({
-        'gifWidth': 400,
-        'gifHeight': 350,
-        'images': imgSrcs,
-        'frameDuration': 7,
-      },
-      function(obj) {
-        if(!obj.error) {
-          var image = obj.image,
-          animatedImage = document.createElement('img');
-          animatedImage.src = image;
-          animatedImage.id = "gif_element";
-          var link = document.createElement('a');
-          var att1 = document.createAttribute("href");
-          att1.value = animatedImage.src;
-          var att2 = document.createAttribute("download");
-          att2.value = "index.gif";
-          link.setAttributeNode(att1);
-          link.setAttributeNode(att2);
-          link.appendChild(animatedImage);
-
-
-          var gifContainer = document.getElementById("download-modal-gif-container")
-
-          // Clear previous results
-          gifContainer.innerHTML = ''
-
-          // Insert image
-          gifContainer.appendChild(link);
-
-          // Trigger modal
-          $('#download-gif-modal').modal()
-          link.click();
-        }
-      });
-
-   }
-
-
-
-
   </script>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "buffer": "~5.0.2",
     "commander": "^2.11.0",
     "data-uri-to-buffer": "^2.0.0",
+    "downloadjs": "^1.4.7",
     "fisheyegl": "^0.1.2",
     "font-awesome": "~4.5.0",
     "get-pixels": "~3.3.0",


### PR DESCRIPTION
Fixes #436

The gif should now appear inside the modal instead of appearing at the bottom of the page.
![](https://user-images.githubusercontent.com/22733656/47454537-234da900-d7d8-11e8-9d5d-1552e82777d8.gif)

Please let me know if i'm doing something wrong.

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

Thanks!
