### PR TITLE
slider now goes all the way to right & left

### DIFF
--- a/examples/demo.css
+++ b/examples/demo.css
@@ -42,6 +42,10 @@ h1 {
   margin: 0 !important;
 }
 
+.form-control {
+  padding: 0px 0px;
+}
+
 #dropzone {
   padding: 30px;
   margin: 0 20% 30px;


### PR DESCRIPTION
Fixes #507

here's a simple fix for slider not going all the way to right & left. It was due to form-control class in the bootstrap library which add padding of 12px to right & left.
This PR is adding a form-control class which overrides the padding settings of the bootstrap library.

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] ask `@publiclab/reviewers` for help, in a comment below


![](https://user-images.githubusercontent.com/34943807/49288155-f884fd80-f4c5-11e8-9e75-bbf1dd598102.png)


Thanks!
