### PR TITLE
Collapse step on click

### DIFF
--- a/examples/demo.css
+++ b/examples/demo.css
@@ -267,7 +267,7 @@ h1 {
 }
 
 .caret-holder.down {
-  transition: rotate(180deg);
+  -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
 }

--- a/examples/demo.css
+++ b/examples/demo.css
@@ -245,13 +245,28 @@ h1 {
 }
 
 .hide {
-  display: none;
+  visiblity: hidden;
 }
 
-.details.collapsed {
+.collapsed  {
+  border-top: 3px solid #444;
   border-bottom: 3px solid #444;
 }
+
+.collapsed .details {
+  border-width: 0px;
+}
+
 .caret-holder {
   position: absolute;
   left: 0px;
+  -webkit-transition: -webkit-transform .2s ease-in-out;
+  -ms-transition: -ms-transform .2s ease-in-out;
+  transition: transform .2s ease-in-out;
+}
+
+.caret-holder.down {
+  transition: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
 }

--- a/examples/demo.css
+++ b/examples/demo.css
@@ -65,6 +65,7 @@ h1 {
 
 .step {
   margin-bottom: 20px;
+  display: flex;
 }
 
 .step .img-thumbnail {
@@ -73,13 +74,18 @@ h1 {
 
 .details {
   border-top: 3px solid #444;
-  padding-left: 6px;
+  padding-left: 16px;
 }
 
 .details h3 {
   font-family: monospace;
   margin-top: 12px;
   font-size: 1.3em;
+  cursor: pointer;
+}
+
+.details h3:hover {
+  color: darkgray;
 }
 
 .det {
@@ -210,4 +216,42 @@ h1 {
   min-width:14rem;
   text-align:center;
   display:none;
+}
+
+.collapse-step {
+  visibility: hidden;
+  position: relative;
+  width: 4px;
+  background-color: red;
+  left: 7px;
+  top: 35px;
+  opacity: 0;
+}
+
+.collapse-step::after {
+  content: "";
+  position: absolute;
+  width: 4px;
+  height: 70px;
+  background-color: #f8f8fa;
+  bottom: 0px;
+}
+
+.collapse-step.show {
+  visibility: visible;
+  background-color: darkgray;
+  opacity: 0.4;
+  transition: visibility 0s, opacity 0.5s linear;
+}
+
+.hide {
+  display: none;
+}
+
+.details.collapsed {
+  border-bottom: 3px solid #444;
+}
+.caret-holder {
+  position: absolute;
+  left: 0px;
 }

--- a/examples/demo.css
+++ b/examples/demo.css
@@ -84,7 +84,7 @@ h1 {
   cursor: pointer;
 }
 
-.details h3:hover {
+.details h3:hover, .details h3.hovered {
   color: darkgray;
 }
 
@@ -251,6 +251,7 @@ h1 {
 .collapsed  {
   border-top: 3px solid #444;
   border-bottom: 3px solid #444;
+  cursor: pointer;
 }
 
 .collapsed .details {

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -183,22 +183,56 @@ window.onload = function() {
   location.reload();
   });
   console.log($('.step h3'));
-  $('body').on('mouseenter', '.step h3', function(e) {
-    console.log(e.target);
-    console.log("hovered");
-    $(e.target).parents('.step').find('.collapse-step').toggleClass('show', true);
+
+  $('body').on('mouseenter', '.step', function(e) {
+    console.log("i just entered");
+    var stepDiv = $(e.target).parents('.step') ;
+    stepDiv = (stepDiv.length) ? stepDiv : $(e.target);
+    console.log("StepDiv:",stepDiv);
+    var hoverDiv = true, clicked = stepDiv.hasClass('clicked'), hoverHeader = false;
+    formatStep(stepDiv, hoverHeader, hoverDiv, clicked);
+
+    stepDiv.find('h3').off('mouseenter').on('mouseenter', function() {
+      hoverHeader = true;
+      formatStep(stepDiv, hoverHeader, hoverDiv, clicked);
+    });
+    stepDiv.find('h3').off('mouseleave').on('mouseleave', function() {
+      hoverHeader = false;
+      formatStep(stepDiv, hoverHeader, hoverDiv, clicked);
+    })
+    stepDiv.find('h3').off('click').on('click', function() {
+      clicked = !clicked;
+      console.log("I JUST CLICKED IT", clicked);
+      stepDiv.toggleClass('clicked');
+      formatStep(stepDiv, hoverHeader, hoverDiv, clicked, true);
+    });
   });
-  $('body').on('mouseleave', '.step h3', function(e) {
-    console.log(e.target);
-    console.log("hovered");
-    $(e.target).parents('.step').find('.collapse-step').toggleClass('show', false);
+
+  $('body').on('mouseleave', '.step', function(e) {
+    console.log('leaving step');
+    stepDiv = $(e.target).parents('.step');
+    var clicked = stepDiv.hasClass('clicked');
+    formatStep(stepDiv, false, false, clicked);
   });
-  $('body').on('click', '.step h3', function(e) {
-    console.log('clicked');
-    var stepDiv = $(e.target).parents('.step');
-    stepDiv.find('.col-md-8').toggleClass('hide');
-    stepDiv.find('.details').children().not('h3').toggleClass('hide');
-    stepDiv.find('.details').toggleClass('collapsed');
-    stepDiv.find('i').toggleClass('fa-caret-down fa-caret-up');
-  });
+
+  function formatStep(stepDiv, hoverHeader, hoverDiv, clicked, forceClose) {
+    forceClose = forceClose || false;
+
+    console.log('hoverHeader:', hoverHeader);
+    console.log('hoverDiv:', hoverDiv);
+    console.log('clicked', clicked);
+    console.log("will show sidebar:", hoverHeader);
+    stepDiv.find('.collapse-step').toggleClass('show', hoverHeader);
+
+    console.log("will put caret down:", (!clicked && hoverHeader) || (clicked && !hoverHeader));
+    stepDiv.find('.caret-holder').toggleClass('down', (!clicked && hoverHeader) || (clicked && !hoverHeader));
+
+    var collapseContent = clicked && !hoverDiv || forceClose;
+
+    console.log("will dissappear content:", collapseContent);
+    stepDiv.toggleClass('collapsed',  collapseContent);
+    stepDiv.find('.col-md-8').toggleClass('hide', collapseContent);
+    stepDiv.find('.details').children().not('h3').toggleClass('hide', collapseContent);
+    console.log("---------------------");
+  }
 };

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -182,14 +182,11 @@ window.onload = function() {
       }
   location.reload();
   });
-  console.log($('.step h3'));
 
   $('body').on('mouseenter click', '.step', function(e) {
-    console.log("i just entered");
     var stepDiv = $(e.target).parents('.step') ;
     stepDiv = (stepDiv.length) ? stepDiv : $(e.target);
     var hoverDiv = true;
-    console.log("StepDiv:",stepDiv);
     var clicked = stepDiv.hasClass('clicked'), hoverHeader = false;
 
     stepDiv.find('h3').off('mouseenter').on('mouseenter', function() {
@@ -202,11 +199,8 @@ window.onload = function() {
     })
 
     stepDiv.off('click').on('click', function(e) {
-      console.log($(e.target).prop('tagName'));
       var notClickedButH = !clicked && ($(e.target).prop('tagName') === 'H3' || $(e.target).parents('h3').length);
-      console.log('not clicked but h3', notClickedButH);
       if(clicked || !clicked && ($(e.target).prop('tagName') === 'H3' || $(e.target).parents('h3').length)) {
-        console.log("successful click");
         clicked = !clicked;
       }
 
@@ -223,7 +217,6 @@ window.onload = function() {
   });
 
   $('body').on('mouseleave', '.step', function(e) {
-    console.log('leaving step');
     var stepDiv = $(e.target).parents('.step');
     stepDiv = (stepDiv.length) ? stepDiv : $(e.target);
     var clicked = stepDiv.hasClass('clicked');
@@ -231,24 +224,17 @@ window.onload = function() {
   });
 
   function formatStep(stepDiv, hoverHeader, clicked, hoverDiv) {
-    console.log('hoverHeader:', hoverHeader);
-    console.log('clicked', clicked);
-    console.log("will show sidebar:", hoverHeader && !clicked);
     stepDiv.find('.collapse-step').toggleClass('show', hoverHeader && !clicked);
 
-    console.log("will put caret down:", (!clicked && hoverHeader) || clicked );
     stepDiv.find('.caret-holder').toggleClass('down', !clicked && hoverHeader || clicked);
 
     var collapseContent = clicked;
 
-    console.log("will dissappear content:", collapseContent);
     stepDiv.toggleClass('collapsed',  collapseContent);
     stepDiv.find('.col-md-8').toggleClass('hide', collapseContent);
     stepDiv.find('.details').children().not('h3').toggleClass('hide', collapseContent);
 
-    console.log('hovered: ', clicked && hoverDiv)
     stepDiv.find('h3').toggleClass('hovered', clicked && hoverDiv);
 
-    console.log("---------------------");
   }
 };

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -184,55 +184,71 @@ window.onload = function() {
   });
   console.log($('.step h3'));
 
-  $('body').on('mouseenter', '.step', function(e) {
+  $('body').on('mouseenter click', '.step', function(e) {
     console.log("i just entered");
     var stepDiv = $(e.target).parents('.step') ;
     stepDiv = (stepDiv.length) ? stepDiv : $(e.target);
+    var hoverDiv = true;
     console.log("StepDiv:",stepDiv);
-    var hoverDiv = true, clicked = stepDiv.hasClass('clicked'), hoverHeader = false;
-    formatStep(stepDiv, hoverHeader, hoverDiv, clicked);
+    var clicked = stepDiv.hasClass('clicked'), hoverHeader = false;
 
     stepDiv.find('h3').off('mouseenter').on('mouseenter', function() {
       hoverHeader = true;
-      formatStep(stepDiv, hoverHeader, hoverDiv, clicked);
+      formatStep(stepDiv, hoverHeader, clicked, hoverDiv);
     });
     stepDiv.find('h3').off('mouseleave').on('mouseleave', function() {
       hoverHeader = false;
-      formatStep(stepDiv, hoverHeader, hoverDiv, clicked);
+      formatStep(stepDiv, hoverHeader, clicked, hoverDiv);
     })
-    stepDiv.find('h3').off('click').on('click', function() {
-      clicked = !clicked;
-      console.log("I JUST CLICKED IT", clicked);
-      stepDiv.toggleClass('clicked');
-      formatStep(stepDiv, hoverHeader, hoverDiv, clicked, true);
+
+    stepDiv.off('click').on('click', function(e) {
+      console.log($(e.target).prop('tagName'));
+      var notClickedButH = !clicked && ($(e.target).prop('tagName') === 'H3' || $(e.target).parents('h3').length);
+      console.log('not clicked but h3', notClickedButH);
+      if(clicked || !clicked && ($(e.target).prop('tagName') === 'H3' || $(e.target).parents('h3').length)) {
+        console.log("successful click");
+        clicked = !clicked;
+      }
+
+      stepDiv.toggleClass('clicked', clicked);
+      formatStep(stepDiv, hoverHeader, clicked, hoverDiv);
     });
+
+    formatStep(stepDiv, hoverHeader, clicked, hoverDiv);
+  });
+
+  $('body').on('click', '.step .clicked', function(e) {
+    var stepDiv = $(e.target).parents('.step') ;
+    stepDiv = (stepDiv.length) ? stepDiv : $(e.target);
   });
 
   $('body').on('mouseleave', '.step', function(e) {
     console.log('leaving step');
-    stepDiv = $(e.target).parents('.step');
+    var stepDiv = $(e.target).parents('.step');
+    stepDiv = (stepDiv.length) ? stepDiv : $(e.target);
     var clicked = stepDiv.hasClass('clicked');
-    formatStep(stepDiv, false, false, clicked);
+    formatStep(stepDiv, false, clicked, false);
   });
 
-  function formatStep(stepDiv, hoverHeader, hoverDiv, clicked, forceClose) {
-    forceClose = forceClose || false;
-
+  function formatStep(stepDiv, hoverHeader, clicked, hoverDiv) {
     console.log('hoverHeader:', hoverHeader);
-    console.log('hoverDiv:', hoverDiv);
     console.log('clicked', clicked);
-    console.log("will show sidebar:", hoverHeader);
-    stepDiv.find('.collapse-step').toggleClass('show', hoverHeader);
+    console.log("will show sidebar:", hoverHeader && !clicked);
+    stepDiv.find('.collapse-step').toggleClass('show', hoverHeader && !clicked);
 
-    console.log("will put caret down:", (!clicked && hoverHeader) || (clicked && !hoverHeader));
-    stepDiv.find('.caret-holder').toggleClass('down', (!clicked && hoverHeader) || (clicked && !hoverHeader));
+    console.log("will put caret down:", (!clicked && hoverHeader) || clicked );
+    stepDiv.find('.caret-holder').toggleClass('down', !clicked && hoverHeader || clicked);
 
-    var collapseContent = clicked && !hoverDiv || forceClose;
+    var collapseContent = clicked;
 
     console.log("will dissappear content:", collapseContent);
     stepDiv.toggleClass('collapsed',  collapseContent);
     stepDiv.find('.col-md-8').toggleClass('hide', collapseContent);
     stepDiv.find('.details').children().not('h3').toggleClass('hide', collapseContent);
+
+    console.log('hovered: ', clicked && hoverDiv)
+    stepDiv.find('h3').toggleClass('hovered', clicked && hoverDiv);
+
     console.log("---------------------");
   }
 };

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -182,4 +182,23 @@ window.onload = function() {
       }
   location.reload();
   });
+  console.log($('.step h3'));
+  $('body').on('mouseenter', '.step h3', function(e) {
+    console.log(e.target);
+    console.log("hovered");
+    $(e.target).parents('.step').find('.collapse-step').toggleClass('show', true);
+  });
+  $('body').on('mouseleave', '.step h3', function(e) {
+    console.log(e.target);
+    console.log("hovered");
+    $(e.target).parents('.step').find('.collapse-step').toggleClass('show', false);
+  });
+  $('body').on('click', '.step h3', function(e) {
+    console.log('clicked');
+    var stepDiv = $(e.target).parents('.step');
+    stepDiv.find('.col-md-8').toggleClass('hide');
+    stepDiv.find('.details').children().not('h3').toggleClass('hide');
+    stepDiv.find('.details').toggleClass('collapsed');
+    stepDiv.find('i').toggleClass('fa-caret-down fa-caret-up');
+  });
 };

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -199,8 +199,7 @@ window.onload = function() {
     })
 
     stepDiv.off('click').on('click', function(e) {
-      var notClickedButH = !clicked && ($(e.target).prop('tagName') === 'H3' || $(e.target).parents('h3').length);
-      if(clicked || !clicked && ($(e.target).prop('tagName') === 'H3' || $(e.target).parents('h3').length)) {
+      if(clicked || !clicked && hoverHeader) {
         clicked = !clicked;
       }
 
@@ -209,11 +208,6 @@ window.onload = function() {
     });
 
     formatStep(stepDiv, hoverHeader, clicked, hoverDiv);
-  });
-
-  $('body').on('click', '.step .clicked', function(e) {
-    var stepDiv = $(e.target).parents('.step') ;
-    stepDiv = (stepDiv.length) ? stepDiv : $(e.target);
   });
 
   $('body').on('mouseleave', '.step', function(e) {
@@ -227,12 +221,9 @@ window.onload = function() {
     stepDiv.find('.collapse-step').toggleClass('show', hoverHeader && !clicked);
 
     stepDiv.find('.caret-holder').toggleClass('down', !clicked && hoverHeader || clicked);
-
-    var collapseContent = clicked;
-
-    stepDiv.toggleClass('collapsed',  collapseContent);
-    stepDiv.find('.col-md-8').toggleClass('hide', collapseContent);
-    stepDiv.find('.details').children().not('h3').toggleClass('hide', collapseContent);
+    stepDiv.toggleClass('collapsed',  clicked);
+    stepDiv.find('.col-md-8').toggleClass('hide', clicked);
+    stepDiv.find('.details').children().not('h3').toggleClass('hide', clicked);
 
     stepDiv.find('h3').toggleClass('hovered', clicked && hoverDiv);
 

--- a/examples/lib/defaultHtmlStepUi.js
+++ b/examples/lib/defaultHtmlStepUi.js
@@ -31,8 +31,12 @@ function DefaultHtmlStepUi(_sequencer, options) {
     step.ui =
       '\
     <div class="row step">\
+    <div class="collapse-step"></div>\
     <div class="col-md-4 details">\
-    <h3>' +
+    <h3>\
+      <span class="caret-holder">\
+        <i class="fa fa-caret-up"></i>\
+      </span>' +
       step.name +
       "</h3>\
     <p><i>" +
@@ -87,7 +91,7 @@ function DefaultHtmlStepUi(_sequencer, options) {
             paramVal +
             '" placeholder ="' +
             (inputDesc.placeholder || "");
-            
+
            if(inputDesc.type.toLowerCase() == "range")
            {
              html+=
@@ -165,7 +169,7 @@ function DefaultHtmlStepUi(_sequencer, options) {
         );
 
     stepsEl.appendChild(step.ui);
-    
+
     var inputs = document.querySelectorAll('input[type="range"]')
     for(i in inputs)
     inputs[i].oninput = function(e) {


### PR DESCRIPTION
Fixes #498 

Collapses step on click. Its 2 AM over here and I don't think I have any more brain power left to test this 😞 . From what I have tried, it seems to work appropriately:

**OLD:
[![Image from Gyazo](https://i.gyazo.com/7f81af13d257b8957d53095f423dc050.gif)](https://gyazo.com/7f81af13d257b8957d53095f423dc050)

[![Image from Gyazo](https://i.gyazo.com/bc1b272019e4a446264e242ead315c2b.gif)](https://gyazo.com/bc1b272019e4a446264e242ead315c2b)

I still want to add a few changes, namely that each section opens on hover and the caret actualy changes to the correct orientation on hover instead of click. **EDIT: I actually implemented this and it doesn't feel very useful, so I ended up removing it

NEW:
![collapsesteps](https://user-images.githubusercontent.com/44309027/49680090-8dec3880-fa56-11e8-89d7-29c4bdada7d6.gif)


Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [X] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [X] code is in uniquely-named feature branch and has no merge conflicts
* [X] PR is descriptively titled
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

Thanks!
