### PR TITLE
Rearrange Sequence Buttons

### DIFF
--- a/examples/demo.css
+++ b/examples/demo.css
@@ -129,6 +129,7 @@ h1 {
 #save-seq {
   display: block;
   margin: 0 auto;
+  min-width: 250px;
 }
 .info {
   padding: 8px;
@@ -137,10 +138,10 @@ h1 {
 #gif {
   display: block;
   margin: 0 auto;
-  margin-top: 4px;
+  min-width: 250px;
 }
 #dwnld {
-  max-width: 200px;
+  max-width: 500px;
   margin: 20px auto;
   margin-left: 5px;
 }

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -9,7 +9,7 @@ window.onload = function() {
       img.src = src;
       $(img).css("max-width", "200%");
       $(img).css("transform", "translateX(-20%)");
-      var stepDiv = $('#addStep .row').find('div').each(function() {
+      var stepDiv = $('#addStep #quick-btn-row').find('div').each(function() {
         if ($(this).find('div').attr('data-value') === previewStepName) {
           $(this).find('div').append(img);
         }
@@ -82,7 +82,7 @@ window.onload = function() {
   });
 
   $('#download-btn').click(function() {
-    $('.img-thumbnail:last()').trigger("click");
+    $('.step-thumbnail:last()').trigger("click");
     return false;
   });
 

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -9,7 +9,7 @@ window.onload = function() {
       img.src = src;
       $(img).css("max-width", "200%");
       $(img).css("transform", "translateX(-20%)");
-      var stepDiv = $('#addStep #quick-btn-row').find('div').each(function() {
+      var stepDiv = $('#addStep .row').find('div').each(function() {
         if ($(this).find('div').attr('data-value') === previewStepName) {
           $(this).find('div').append(img);
         }

--- a/examples/index.html
+++ b/examples/index.html
@@ -86,7 +86,7 @@
       <div class="form-inline">
         <div class="panel-body">
           <p class="info">Select a new module to add to your sequence.</p>
-          <div class="row center-align radio-group">
+          <div class="row center-align radio-group" id="quick-btn-row">
             <div>
               <div class="radio" data-value="brightness">
                 <i class="fa fa-sun-o fa-4x i-over"></i>

--- a/examples/index.html
+++ b/examples/index.html
@@ -86,7 +86,7 @@
       <div class="form-inline">
         <div class="panel-body">
           <p class="info">Select a new module to add to your sequence.</p>
-          <div class="row center-align radio-group" id="quick-btn-row">
+          <div class="row center-align radio-group">
             <div>
               <div class="radio" data-value="brightness">
                 <i class="fa fa-sun-o fa-4x i-over"></i>

--- a/examples/index.html
+++ b/examples/index.html
@@ -128,6 +128,40 @@
         </div>
       </div>
     </section>
+
+    <section id="sequence-actions" class="panel">
+      <div class="panel-body">
+
+        <div class="row center-align">
+          <button class="btn btn-primary btn-lg" name="save-sequence" id="save-seq">Save Sequence</button>
+          <button class="btn btn-primary btn-lg js-view-as-gif" id="gif">View GIF</button>
+        </div>
+
+
+        <div class="modal fade" id="js-download-gif-modal" tabindex="-1" role="dialog">
+          <div class="modal-dialog" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Your gif is ready</h4>
+              </div>
+              <div class="modal-body">
+                <div id="js-download-modal-gif-container">
+                  <!-- Gif should appear here -->
+                </div>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Done</button>
+
+                <button id="js-download-as-gif-button" class="btn btn-primary">Download</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </section>
+
     </div>
     <div class="col-sm-4">
     <section id="dwnld" class="panel panel-primary">
@@ -135,37 +169,11 @@
         <div class="panel-body">
           <div style="text-align:center;">
             <button class="btn btn-success btn-lg" id="download-btn" name="download">Download PNG</button>
-            <button class="btn btn-success btn-lg js-view-as-gif" id="gif">View GIF</button>
-
-            <div class="modal fade" id="js-download-gif-modal" tabindex="-1" role="dialog">
-              <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                  <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                    <h4 class="modal-title">Your gif is ready</h4>
-                  </div>
-                  <div class="modal-body">
-                    <div id="js-download-modal-gif-container">
-                      <!-- Gif should appear here -->
-                    </div>
-                  </div>
-                  <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Done</button>
-
-                    <button id="js-download-as-gif-button" class="btn btn-primary">Download</button>
-                  </div>
-                </div>
-              </div>
-            </div>
           </div>
-
         </div>
       </div>
     </section>
     </div>
-  </div>
-  <div class="row">
-    <button class="btn btn-primary btn-lg" name="save-sequence" id="save-seq">Save Sequence</button>
   </div>
 
   <form class="move-up" action="#up">

--- a/examples/lib/defaultHtmlStepUi.js
+++ b/examples/lib/defaultHtmlStepUi.js
@@ -41,7 +41,7 @@ function DefaultHtmlStepUi(_sequencer, options) {
     </div>\
     <div class="col-md-8">\
     <div class="load" style="display:none;"><i class="fa fa-circle-o-notch fa-spin"></i></div>\
-    <a><img alt="" style="max-width=100%" class="img-thumbnail" /></a>\
+    <a><img alt="" style="max-width=100%" class="img-thumbnail step-thumbnail"/></a>\
     </div>\
     </div>\
     </div>\


### PR DESCRIPTION
Fixes https://github.com/publiclab/image-sequencer/issues/493

Rearranged the GIF and save sequence buttons and grouped them together.

![screenshot from 2018-12-22 18-39-05](https://user-images.githubusercontent.com/34770591/50374721-e60b6900-0618-11e9-8d06-a2624ae5696b.png)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

Thanks!
