### PR TITLE
  Fixed Typos in EdgeDetect/Module.js #884

### DIFF
--- a/src/modules/EdgeDetect/Module.js
+++ b/src/modules/EdgeDetect/Module.js
@@ -7,7 +7,7 @@ module.exports = function edgeDetect(options, UI) {
   options.blur = options.blur || defaults.blur;
   options.highThresholdRatio = options.highThresholdRatio || defaults.highThresholdRatio;
   options.lowThresholdRatio = options.lowThresholdRatio || defaults.lowThresholdRatio;
-  options.hystereis = options.hysteresis || defaults.hysteresis;
+  options.hysteresis = options.hysteresis || defaults.hysteresis;
 
   var output;
 
@@ -27,7 +27,7 @@ module.exports = function edgeDetect(options, UI) {
 
     function extraManipulation(pixels) {
       pixels = require('ndarray-gaussian-filter')(pixels, options.blur);
-      pixels = require('./EdgeUtils')(pixels, options.highThresholdRatio, options.lowThresholdRatio, options.hystereis);
+      pixels = require('./EdgeUtils')(pixels, options.highThresholdRatio, options.lowThresholdRatio, options.hysteresis);
       return pixels;
     }
 


### PR DESCRIPTION
Fixes #884

Fix Typo In EdgeDetect Module #884.

Fixed On line 10

-  options.hystereis = options.hysteresis || defaults.hysteresis;
+  options.hysteresis = options.hysteresis || defaults.hysteresis;

And on line 30

-      pixels = require('./EdgeUtils')(pixels, options.highThresholdRatio, options.lowThresholdRatio, options.hystereis);
+      pixels = require('./EdgeUtils')(pixels, options.highThresholdRatio, options.lowThresholdRatio, options.hysteresis);
