### PR TITLE
corrected script tag and removed scrollToTop script tag

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -27,9 +27,8 @@
   <script src="../node_modules/gifshot/dist/gifshot.min.js" type="text/javascript"></script>
 
   <!-- Download.js for large files -->
-  <script src="../node_modules/downloadjs/download.min.js" type="text/javascript"/>
+  <script src="../node_modules/downloadjs/download.min.js" type="text/javascript"></script>/>
 
-  <script src="lib/scrollToTop.js"></script>
   <script src="../node_modules/selectize/dist/js/standalone/selectize.min.js"></script>
 </head>
 


### PR DESCRIPTION
Fixes #

there is no `scrollToTop` script in `lib` folder so I removed it from `index.html` and script tag for `download.min.js` was used as a self closing tag so this PR made these 2 changes.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `npm test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] ask `@publiclab/is-reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

Thanks!
