### PR TITLE
fix: module names had spaces instead of hyphen

### DIFF
--- a/examples/lib/defaultHtmlSequencerUi.js
+++ b/examples/lib/defaultHtmlSequencerUi.js
@@ -44,7 +44,7 @@ function DefaultHtmlSequencerUi(_sequencer, options) {
     if ($(addStepSel + ' select').val() == 'none') return;
     var newStepName;
     if(typeof arguments[0] !== 'string')
-      newStepName = $(addStepSel + ' select option').html().toLowerCase();
+      newStepName = $(addStepSel + ' select option').html().toLowerCase().split(' ').join('-');
     else newStepName = arguments[0];
 
     


### PR DESCRIPTION
Fixes #1061  (<=== Replace `0000` with the Issue Number)

modules names had spaces instead of a hyphen and were generating this error 
![Screenshot 2019-05-23 at 02 49 25](https://user-images.githubusercontent.com/34943807/58210993-4b6a9f80-7d08-11e9-910b-ec8197eaca60.png)


Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `npm test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] ask `@publiclab/is-reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

Thanks!
