### PR TITLE
Make "Add Step" button blue

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -148,7 +148,7 @@
                   </select>
                 </div>
                 <div class="col-lg-4">
-                  <button class="btn btn-success btn-lg" name="add" id="add-step-btn">Add Step</button></div>
+                  <button class="btn btn-primary btn-lg" name="add" id="add-step-btn">Add Step</button></div>
               </div>
               <div class="row center-align">
                 <button id="resetButton" class="btn btn-default btn-lg"


### PR DESCRIPTION
I changed the "Add Step" button's class from "btn-success" to "btn-primary," to make it blue. This means the "btn-success" CSS rule might no longer be used, but I haven't changed any CSS, in case the "btn-success" class is used elsewhere.
Here is a screenshot:
![image](https://user-images.githubusercontent.com/37421108/70356781-cde92580-183a-11ea-9248-f00aaafd3041.png)

Note: I also claimed this task on Google Code-in. My Google Code-in username is az.

Fixes #1317 

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `npm test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] ask `@publiclab/is-reviewers` for help, in a comment below
* [x] Insert-step functionality is working correct as expected.
> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software
Please make sure to get at least two reviews before asking for merging the PR as that would make the PR more reliable on our part
Thanks!
