### PR TITLE
Disables Take a Photo Button and File Chooser While Camera is Active

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -76,7 +76,7 @@
     </header>
 
     <div id="dropzone" class="dropzone">
-      <p>
+      <p id="dropzone-text">
         <i>Select or drag in an image to start!</i>
       </p>
       <center>

--- a/src/modules/ImportImage/Ui.js
+++ b/src/modules/ImportImage/Ui.js
@@ -9,7 +9,7 @@ module.exports = function ImportImageModuleUi(step, ui) {
     // add a file input listener
     var dropZone = '\
     <div class="dropzone import-image-zone" id="' + dropzoneId + '">\
-          <p id="dropzone-text">\
+          <p>\
         <i>Select or drag in an image to overlay.</i>\
       </p>\
       <center>\

--- a/src/modules/ImportImage/Ui.js
+++ b/src/modules/ImportImage/Ui.js
@@ -9,7 +9,7 @@ module.exports = function ImportImageModuleUi(step, ui) {
     // add a file input listener
     var dropZone = '\
     <div class="dropzone import-image-zone" id="' + dropzoneId + '">\
-          <p>\
+          <p id="dropzone-text">\
         <i>Select or drag in an image to overlay.</i>\
       </p>\
       <center>\

--- a/src/ui/SetInputStep.js
+++ b/src/ui/SetInputStep.js
@@ -33,6 +33,10 @@ function setInputStepInit() {
       document.getElementById('video').style.display = 'inline';
       document.getElementById('capture').style.display = 'inline';
       document.getElementById('close').style.display = 'inline';
+
+      fileInput.css('display', 'none');
+      takePhoto.css('display', 'none');
+      document.getElementById('dropzone-text').style.display = 'none';
       
       var video = document.getElementById('video');
       canvas = document.getElementById('canvas'),
@@ -69,6 +73,10 @@ function setInputStepInit() {
         document.getElementById('video').style.display = 'none';
         document.getElementById('capture').style.display = 'none';
         document.getElementById('close').style.display = 'none';
+
+        fileInput.css('display', 'block');
+        takePhoto.css('display', 'block');
+        document.getElementById('dropzone-text').style.display = 'block';
       }
     }
  


### PR DESCRIPTION
Fixes #1321

This disables the other two buttons after the "Take a Photo" button is pressed and reenables them once the camera is closed.

Before "Take a Photo" is pressed and after camera is closed:
![Screen Shot 2019-12-13 at 9 04 17 PM](https://user-images.githubusercontent.com/8119928/70841998-2006e980-1ded-11ea-95ca-e63038b832ed.png)

After "Take a Photo" is pressed (I covered the webcam with my finger which is why the camera stream appears all black):
![Screen Shot 2019-12-13 at 9 04 28 PM](https://user-images.githubusercontent.com/8119928/70842009-2bf2ab80-1ded-11ea-9696-1f263904d727.png)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `npm test`
* [X] code is in uniquely-named feature branch and has no merge conflicts
* [X] PR is descriptively titled
* [x] ask `@publiclab/is-reviewers` for help, in a comment below
* [X] Insert-step functionality is working correct as expected.
> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software
Please make sure to get at least two reviews before asking for merging the PR as that would make the PR more reliable on our part
Thanks!
