### PR TITLE
Fix .gitpod.yml configuration syntax

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,6 @@ ports:
 
 github:
   prebuilds:
-    main: true
     branches: true
     pullRequests: true
     pullRequestsFromForks: true


### PR DESCRIPTION
Fixes #1681

Hi team! As explained in https://github.com/gitpod-io/gitpod/issues/1646#issuecomment-654080074 the `.gitpod.yml` option to enable prebuilds on the default branch (in your case `main`) is wrongly called `master` in Gitpod (regardless of the actual default branch name).

I notice that you've renamed your repository's default branch from `master` to `main`, but inadvertently broken the `.gitpod.yml` syntax by also renaming the prebuild option from `master` to `main` (but there is no prebuild configuration option called `main` in `.gitpod.yml`).

To fix this, I propose two things:
- Fixing your `.gitpod.yml` syntax, either by renaming the prebuild option back to `master`, or by removing the option (its default value is `true`, so there is no need to explicitly define it)
- In Gitpod, we should rename and/or alias the `github.prebuilds.master` option to a better and more accurate name like `github.prebuilds.default` or `github.prebuilds.defaultBranch` (see https://github.com/gitpod-io/gitpod/issues/1646)

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `npm run test-all`
* [ ] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [ ] ask `@publiclab/is-reviewers` for help, in a comment below
* [ ] Insert-step functionality is working correct as expected.