### PR TITLE
Update .gitpod.yml to include gitpod dependencies in a mini dockerfile

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -4,4 +4,4 @@ USER root
 RUN sudo apt-get update \
  && sudo apt-get install -y \
     install xserver-xorg-dev libxext-dev libxi-dev build-essential libxi-dev libglu1-mesa-dev libglew-dev pkg-config libglu1-mesa-dev freeglut3-dev mesa-common-dev \
- && sudo rm -rf /var/lib/apt/lists/*
+ && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -3,5 +3,5 @@ FROM gitpod/workspace-full
 USER root
 RUN sudo apt-get update && apt-get install -y apt-transport-https \
  && sudo apt-get install -y \
-    install xserver-xorg-dev libxext-dev libxi-dev build-essential libxi-dev libglu1-mesa-dev libglew-dev pkg-config libglu1-mesa-dev freeglut3-dev mesa-common-dev \
+    xserver-xorg-dev libxext-dev libxi-dev build-essential libxi-dev libglu1-mesa-dev libglew-dev pkg-config libglu1-mesa-dev freeglut3-dev mesa-common-dev \
  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,7 +1,7 @@
 FROM gitpod/workspace-full
 
 USER root
-RUN sudo apt-get update \
+RUN sudo apt-get update && apt-get install -y apt-transport-https \
  && sudo apt-get install -y \
     install xserver-xorg-dev libxext-dev libxi-dev build-essential libxi-dev libglu1-mesa-dev libglew-dev pkg-config libglu1-mesa-dev freeglut3-dev mesa-common-dev \
  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,5 +1,6 @@
 FROM gitpod/workspace-full
 
+USER root
 RUN sudo apt-get update \
  && sudo apt-get install -y \
     install xserver-xorg-dev libxext-dev libxi-dev build-essential libxi-dev libglu1-mesa-dev libglew-dev pkg-config libglu1-mesa-dev freeglut3-dev mesa-common-dev \

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,6 @@
+FROM gitpod/workspace-full
+
+RUN sudo apt-get update \
+ && sudo apt-get install -y \
+    install xserver-xorg-dev libxext-dev libxi-dev build-essential libxi-dev libglu1-mesa-dev libglew-dev pkg-config libglu1-mesa-dev freeglut3-dev mesa-common-dev \
+ && sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,5 @@
+image:
+  file: .gitpod.dockerfile
 tasks:
   - init: npm run setup
     command: npm start


### PR DESCRIPTION
Possible solution to fix #1681, building on https://www.gitpod.io/blog/gitpodify/#installing-missing-packages

Adding deps from https://github.com/publiclab/image-sequencer/blob/fb303a8ca9e5f605023725b2d3d1dbb5809994b0/.travis.yml#L42-L43