### PR TITLE
Bump lockfile and sw.js versions for v3.6.0

### DIFF
--- a/examples/sw.js
+++ b/examples/sw.js
@@ -1,4 +1,4 @@
-const staticCacheName = 'image-sequencer-static-v3.5.1';
+const staticCacheName = 'image-sequencer-static-v3.6.0';
 self.addEventListener('install', event => {
   console.log('Attempting to install service worker');
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "image-sequencer",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5224,7 +5224,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -8550,7 +8550,7 @@
         },
         "split": {
           "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+          "resolved": "http://registry.npmjs.org/split/-/split-0.3.3.tgz",
           "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
           "dev": true,
           "requires": {
@@ -16696,7 +16696,7 @@
     },
     "split": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/split/-/split-1.0.0.tgz",
       "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
       "dev": true,
       "requires": {
@@ -17243,7 +17243,7 @@
       "dependencies": {
         "split": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/split/-/split-0.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/split/-/split-0.1.2.tgz",
           "integrity": "sha1-8HEHRMRT1VH8cUPq2YPaYBTjNsw=",
           "dev": true,
           "requires": {
@@ -17252,7 +17252,7 @@
         },
         "through": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/through/-/through-1.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/through/-/through-1.1.2.tgz",
           "integrity": "sha1-NEpUJaN3MxTKfg62US+6+vdsC/4=",
           "dev": true
         }
@@ -17627,7 +17627,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -17651,7 +17651,7 @@
       "dependencies": {
         "duplexer": {
           "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.0.4.tgz",
           "integrity": "sha1-r8t/H4uNdPggcmFx1dZKyeSo/yA=",
           "dev": true
         }


### PR DESCRIPTION
Fixes #0000  (<=== Replace `0000` with the Issue Number)

The package.json version was bumped to v3.6.0 but lockfile and sw.js was not.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `npm run test-all`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] ask `@publiclab/is-reviewers` for help, in a comment below
* [x] Insert-step functionality is working correct as expected.
> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software
Please make sure to get at least two reviews before asking for merging the PR as that would make the PR more reliable on our part
Thanks!
