### PR TITLE
switch to `npm ci` for GitHub Action CI instead of `npm install` 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
     - name: Install Dependencies
-      run: npm install
+      run: npm ci
     - name: "Base istanbul/tape node tests"
       run: npm test
 


### PR DESCRIPTION
to save time!


follow-up to #1783 #1787 