### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,8 @@ Make sure these boxes are checked before your pull request (PR) is ready to be r
 * [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `npm run test-all`
 * [ ] code is in uniquely-named feature branch and has no merge conflicts
 * [ ] PR is descriptively titled
-* [ ] ask `@publiclab/is-reviewers` for help, in a comment below
+* [ ] ask `@publiclab/is-reviewers` for help, in a comment below 
+* [ ] atleast 2 reviews required for getting pull request merged
 * [ ] Insert-step functionality is working correct as expected.
 > We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!
 


### PR DESCRIPTION
CHANGING PULL REQUEST TEMPLATE FOR ASKING CONTRIBUTORS TO GET ATLEAST TWO REVIEW TO GET PULL REQUEST MERGED.

Fixes #1319  (<=== Replace `0000` with the Issue Number)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `npm run test-all`
* [ ] code is in uniquely-named feature branch and has no merge conflicts
* [ ] PR is descriptively titled
* [ ] ask `@publiclab/is-reviewers` for help, in a comment below
* [ ] Insert-step functionality is working correct as expected.
> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software
Please make sure to get at least two reviews before asking for merging the PR as that would make the PR more reliable on our part
Thanks!
