### PR TITLE
fix: hide docs link for load-image step - fixes #1525

### DIFF
--- a/examples/lib/defaultHtmlStepUi.js
+++ b/examples/lib/defaultHtmlStepUi.js
@@ -51,7 +51,7 @@ function DefaultHtmlStepUi(_sequencer, options) {
               <div class="row step">\
                 <div class="col-md-4 details container-fluid">\
                   <div class="cal collapse in"><p>' +
-                    '<a href="' + stepDocsLink + '">' + (step.description || '') + '</a>' +
+                    (stepDocsLink ? '<a href="' + stepDocsLink + '">' + (step.description || '') + '</a>' : (step.description || '')) +
                  '</p></div>\
                 </div>\
                 <div class="col-md-8 cal collapse in step-column">\


### PR DESCRIPTION
## What does this PR do?
Fixes #1525

## Changes made
- Modified `examples/lib/defaultHtmlStepUi.js` to only show 
  the docs link when `stepDocsLink` exists
- For the load-image step where no docs exist, the description 
  is now shown as plain text instead of a broken link
- All other steps still show their description as a clickable 
  link to their docs

## Checklist
- [x] No existing functionality broken
- [x] Fix is minimal and scoped to the affected line only